### PR TITLE
Fix clang v12 FPE

### DIFF
--- a/Redistribution/hydro_state_redistribute.cpp
+++ b/Redistribution/hydro_state_redistribute.cpp
@@ -358,7 +358,7 @@ Redistribution::StateRedistribute ( Box const& bx, int ncomp,
     {
         if (!flag(i,j,k).isCovered())
         {
-            U_out(i,j,k,n) /= nrs(i,j,k);
+            U_out(i,j,k,n) /= (nrs(i,j,k) + 1.e-40);
         }
         else
         {


### PR DESCRIPTION
Hi all,

This is a bit of a weird one... Clang V12 throws an FPE in this bit of code for some reason. It is hard to figure out exactly what is going on because it doesn't show up in a debug build. Nor does it show up with clang v11, gcc, or intel. But rewriting the code as done in this PR makes it go away. 

The FPE can be seen being thrown in the CI of this commit: https://github.com/AMReX-Combustion/PeleC/pull/284/commits/d41d6798fc84eb1d84639c08ee2588e57006b256

And it goes away if I use the code in this PR: https://github.com/AMReX-Combustion/PeleC/pull/284

If anyone has a better idea of what's going on, I am happy to hear it. But it is proving quite elusive.