### PR TITLE
Use && instead of and for Intel OneAPI compatibility

### DIFF
--- a/Redistribution/hydro_create_itracker_2d.cpp
+++ b/Redistribution/hydro_create_itracker_2d.cpp
@@ -176,11 +176,11 @@ Redistribution::MakeITracker ( Box const& bx,
                ioff = imap[itracker(i,j,k,1)] + imap[itracker(i,j,k,2)];
                joff = jmap[itracker(i,j,k,1)] + jmap[itracker(i,j,k,2)];
 
-               if (ioff > 0 and joff > 0)
+               if (ioff > 0 && joff > 0)
                    itracker(i,j,k,3) = 8;
-               else if (ioff < 0 and joff > 0)
+               else if (ioff < 0 && joff > 0)
                    itracker(i,j,k,3) = 6;
-               else if (ioff > 0 and joff < 0)
+               else if (ioff > 0 && joff < 0)
                    itracker(i,j,k,3) = 3;
                else
                    itracker(i,j,k,3) = 1;

--- a/Redistribution/hydro_create_itracker_3d.cpp
+++ b/Redistribution/hydro_create_itracker_3d.cpp
@@ -181,7 +181,7 @@ Redistribution::MakeITracker ( Box const& bx,
            if ( (sum_vol < 0.5) || just_broke_symmetry )
            {
                // Original offset was in x-direction
-               if (joff == 0 and koff == 0)
+               if (joff == 0 && koff == 0)
                {
                    if (nx_eq_ny) {
                        itracker(i,j,k,2) = (ny > 0) ? 7 : 2;
@@ -194,7 +194,7 @@ Redistribution::MakeITracker ( Box const& bx,
                    }
 
                // Original offset was in y-direction
-               } else if (ioff == 0 and koff == 0)
+               } else if (ioff == 0 && koff == 0)
                {
                    if (nx_eq_ny) {
                        itracker(i,j,k,2) = (nx > 0) ? 5 : 4;
@@ -207,7 +207,7 @@ Redistribution::MakeITracker ( Box const& bx,
                    }
 
                // Original offset was in z-direction
-               } else if (ioff == 0 and joff == 0)
+               } else if (ioff == 0 && joff == 0)
                {
                    if (nx_eq_nz) {
                        itracker(i,j,k,2) = (nx > 0) ? 5 : 4;
@@ -249,33 +249,33 @@ Redistribution::MakeITracker ( Box const& bx,
                // Both nbors are in the koff=0 plane
                if (koff == 0)
                {
-                   if (ioff > 0 and joff > 0)
+                   if (ioff > 0 && joff > 0)
                        itracker(i,j,k,3) = 8;
-                   else if (ioff < 0 and joff > 0)
+                   else if (ioff < 0 && joff > 0)
                        itracker(i,j,k,3) = 6;
-                   else if (ioff > 0 and joff < 0)
+                   else if (ioff > 0 && joff < 0)
                        itracker(i,j,k,3) = 3;
                    else
                        itracker(i,j,k,3) = 1;
 
                // Both nbors are in the joff=0 plane
                } else if (joff == 0) {
-                   if (ioff > 0 and koff > 0)
+                   if (ioff > 0 && koff > 0)
                        itracker(i,j,k,3) = 23;
-                   else if (ioff < 0 and koff > 0)
+                   else if (ioff < 0 && koff > 0)
                        itracker(i,j,k,3) = 21;
-                   else if (ioff > 0 and koff < 0)
+                   else if (ioff > 0 && koff < 0)
                        itracker(i,j,k,3) = 14;
                    else
                        itracker(i,j,k,3) = 12;
 
                // Both nbors are in the ioff=0 plane
                } else {
-                   if (joff > 0 and koff > 0)
+                   if (joff > 0 && koff > 0)
                        itracker(i,j,k,3) = 25;
-                   else if (joff < 0 and koff > 0)
+                   else if (joff < 0 && koff > 0)
                        itracker(i,j,k,3) = 19;
-                   else if (joff > 0 and koff < 0)
+                   else if (joff > 0 && koff < 0)
                        itracker(i,j,k,3) = 16;
                    else
                        itracker(i,j,k,3) = 10;
@@ -322,11 +322,11 @@ Redistribution::MakeITracker ( Box const& bx,
                            else
                                itracker(i,j,k,6) =  19;
 
-                           if (ioff > 0 and joff > 0) {
+                           if (ioff > 0 && joff > 0) {
                                itracker(i,j,k,7) = 26;
-                           } else if (ioff < 0 and joff > 0) {
+                           } else if (ioff < 0 && joff > 0) {
                                itracker(i,j,k,7) = 24;
-                           } else if (ioff > 0 and joff < 0) {
+                           } else if (ioff > 0 && joff < 0) {
                                itracker(i,j,k,7) = 20;
                            } else {
                                itracker(i,j,k,7) = 18;
@@ -344,11 +344,11 @@ Redistribution::MakeITracker ( Box const& bx,
                            else
                                itracker(i,j,k,6) =  10;
 
-                           if (ioff > 0 and joff > 0) {
+                           if (ioff > 0 && joff > 0) {
                                itracker(i,j,k,7) = 17;
-                           } else if (ioff < 0 and joff > 0) {
+                           } else if (ioff < 0 && joff > 0) {
                                itracker(i,j,k,7) = 15;
-                           } else if (ioff > 0 and joff < 0) {
+                           } else if (ioff > 0 && joff < 0) {
                                itracker(i,j,k,7) = 11;
                            } else {
                                itracker(i,j,k,7) =  9;
@@ -368,11 +368,11 @@ Redistribution::MakeITracker ( Box const& bx,
                            else
                                itracker(i,j,k,6) =  16;
 
-                           if (ioff > 0 and koff > 0) {
+                           if (ioff > 0 && koff > 0) {
                                itracker(i,j,k,7) = 26;
-                           } else if (ioff < 0 and koff > 0) {
+                           } else if (ioff < 0 && koff > 0) {
                                itracker(i,j,k,7) = 24;
-                           } else if (ioff > 0 and koff < 0) {
+                           } else if (ioff > 0 && koff < 0) {
                                itracker(i,j,k,7) = 17;
                            } else {
                                itracker(i,j,k,7) = 15;
@@ -391,11 +391,11 @@ Redistribution::MakeITracker ( Box const& bx,
                            else
                                itracker(i,j,k,6) =  19;
 
-                           if (ioff > 0 and koff > 0) {
+                           if (ioff > 0 && koff > 0) {
                                itracker(i,j,k,7) = 26;
-                           } else if (ioff < 0 and koff > 0) {
+                           } else if (ioff < 0 && koff > 0) {
                                itracker(i,j,k,7) = 24;
-                           } else if (ioff > 0 and koff < 0) {
+                           } else if (ioff > 0 && koff < 0) {
                                itracker(i,j,k,7) = 20;
                            } else {
                                itracker(i,j,k,7) = 21;
@@ -416,11 +416,11 @@ Redistribution::MakeITracker ( Box const& bx,
                            else
                                itracker(i,j,k,6) =  14;
 
-                           if (joff > 0 and koff > 0) {
+                           if (joff > 0 && koff > 0) {
                                itracker(i,j,k,7) = 26;
-                           } else if (joff < 0 and koff > 0) {
+                           } else if (joff < 0 && koff > 0) {
                                itracker(i,j,k,7) = 20;
-                           } else if (joff > 0 and koff < 0) {
+                           } else if (joff > 0 && koff < 0) {
                                itracker(i,j,k,7) = 17;
                            } else {
                                itracker(i,j,k,7) = 11;
@@ -438,11 +438,11 @@ Redistribution::MakeITracker ( Box const& bx,
                            else
                                itracker(i,j,k,6) =  12;
 
-                           if (joff > 0 and koff > 0) {
+                           if (joff > 0 && koff > 0) {
                                itracker(i,j,k,7) = 24;
-                           } else if (joff < 0 and koff > 0) {
+                           } else if (joff < 0 && koff > 0) {
                                itracker(i,j,k,7) = 18;
-                           } else if (joff > 0 and koff < 0) {
+                           } else if (joff > 0 && koff < 0) {
                                itracker(i,j,k,7) = 15;
                            } else {
                                itracker(i,j,k,7) =  9;


### PR DESCRIPTION
I'm finding the `and`, `or`, and `not` keywords to be incompatible with DPC++.