### PR TITLE
Fix shadow variable compiler warning

### DIFF
--- a/Redistribution/hydro_create_itracker_3d.cpp
+++ b/Redistribution/hydro_create_itracker_3d.cpp
@@ -287,7 +287,7 @@ Redistribution::MakeITracker ( Box const& bx,
                sum_vol += vfrac(i+ioff,j+joff,k+koff);
 
                // All nbors are currently in one of three planes
-               bool just_broke_symmetry = ( ( (koff == 0) && (nx_eq_nz || ny_eq_nz) ) ||
+               just_broke_symmetry = ( ( (koff == 0) && (nx_eq_nz || ny_eq_nz) ) ||
                                             ( (joff == 0) && (nx_eq_ny || ny_eq_nz) ) ||
                                             ( (ioff == 0) && (nx_eq_ny || nx_eq_nz) ) );
 


### PR DESCRIPTION
`just_broke_symmetry` was already declared in the outer scope, I think its safe to simply re-use inside. It avoids the compiler warning about the variable being shadowed.