### PR TITLE
Fix EB regular checks

### DIFF
--- a/EBGodunov/hydro_ebgodunov.cpp
+++ b/EBGodunov/hydro_ebgodunov.cpp
@@ -99,7 +99,6 @@ EBGodunov::ComputeAofs ( MultiFab& aofs, const int aofs_comp, const int ncomp,
 	// We predict the state on the edge based box; that calls slopes on
 	// i & i-1; slopes then looks at (i-1)-2 for 4th order slopes
 	// => test on bx grow 3
-	//don't forget to check on MOL too....
         bool regular = (flagfab.getType(amrex::grow(bx,3)) == FabType::regular);
 
         // Get handlers to Array4

--- a/EBGodunov/hydro_ebgodunov.cpp
+++ b/EBGodunov/hydro_ebgodunov.cpp
@@ -95,9 +95,12 @@ EBGodunov::ComputeAofs ( MultiFab& aofs, const int aofs_comp, const int ncomp,
         const Box& bx   = mfi.tilebox();
 
         auto const& flagfab = ebfact.getMultiEBCellFlagFab()[mfi];
-	// If cut cells are involved, slopes are 2nd order => we only need to
-	// need to check regular on grow(bx,2).
-        bool regular = (flagfab.getType(amrex::grow(bx,2)) == FabType::regular);
+	// A regular box uses 3 ghost cells:
+	// We predict the state on the edge based box; that calls slopes on
+	// i & i-1; slopes then looks at (i-1)-2 for 4th order slopes
+	// => test on bx grow 3
+	//don't forget to check on MOL too....
+        bool regular = (flagfab.getType(amrex::grow(bx,3)) == FabType::regular);
 
         // Get handlers to Array4
         //
@@ -409,7 +412,7 @@ EBGodunov::ComputeSyncAofs ( MultiFab& aofs, const int aofs_comp, const int ncom
         const Box& bx   = mfi.tilebox();
 
         auto const& flagfab = ebfact.getMultiEBCellFlagFab()[mfi];
-        bool regular = (flagfab.getType(amrex::grow(bx,2)) == FabType::regular);
+        bool regular = (flagfab.getType(amrex::grow(bx,3)) == FabType::regular);
 
         //
         // Get handlers to Array4

--- a/EBGodunov/hydro_ebgodunov_extrap_vel_to_faces.cpp
+++ b/EBGodunov/hydro_ebgodunov_extrap_vel_to_faces.cpp
@@ -52,7 +52,6 @@ EBGodunov::ExtrapVelToFaces ( MultiFab const& vel,
         for (MFIter mfi(vel,TilingIfNotGPU()); mfi.isValid(); ++mfi)
         {
             Box const& bx = mfi.tilebox();
-            Box const& bxg2 = amrex::grow(bx,2);
 
             EBCellFlagFab const& flagfab = flags[mfi];
             Array4<EBCellFlag const> const& flagarr = flagfab.const_array();
@@ -64,56 +63,71 @@ EBGodunov::ExtrapVelToFaces ( MultiFab const& vel,
             Array4<Real const> const& a_vel = vel.const_array(mfi);
             Array4<Real const> const& a_f = vel_forces.const_array(mfi);
 
-            // Not all the arrays have exactly the size of bxg3 but none are bigger
-            // In 2-d:
-            //  8*ncomp are:  Imx, Ipx, Imy, Ipy, xlo/xhi, ylo/yhi
-            //  2       are:  u_ad, v_ad
-            // In 3-d:
-            // 12*ncomp are:  Imx, Ipx, Imy, Ipy, Imz, Ipz, xlo/xhi, ylo/yhi, zlo/zhi
-            //  3       are:  u_ad, v_ad, w_ad
-            Box const& bxg3 = amrex::grow(bx,3);
-            scratch.resize(bxg3, 4*AMREX_SPACEDIM*ncomp + AMREX_SPACEDIM);
-            Real* p  = scratch.dataPtr();
+	    // Not all the arrays have exactly the size of bxg3 but none are bigger
+	    // In 2-d:
+	    //  8*ncomp are:  Imx, Ipx, Imy, Ipy, xlo/xhi, ylo/yhi
+	    //  2       are:  u_ad, v_ad
+	    // In 3-d:
+	    // 12*ncomp are:  Imx, Ipx, Imy, Ipy, Imz, Ipz, xlo/xhi, ylo/yhi, zlo/zhi
+	    //  3       are:  u_ad, v_ad, w_ad
+	    //
+	    // This also over-allots for EB regular boxes, which need grow(bx,1)
+	    // vs. grow(bx,3) here
+	    Box const& bxg3 = amrex::grow(bx,3);
+	    scratch.resize(bxg3, 4*AMREX_SPACEDIM*ncomp + AMREX_SPACEDIM);
+	    Real* p  = scratch.dataPtr();
 
             AMREX_D_TERM(Box const& xbx = mfi.nodaltilebox(0);,
                          Box const& ybx = mfi.nodaltilebox(1);,
                          Box const& zbx = mfi.nodaltilebox(2));;
 
-            AMREX_D_TERM(Box xebx(Box(bx).grow(1).surroundingNodes(0));,
-                         Box yebx(Box(bx).grow(1).surroundingNodes(1));,
-                         Box zebx(Box(bx).grow(1).surroundingNodes(2)));
+	    AMREX_D_TERM(Box xebx(Box(bx).grow(1).surroundingNodes(0));,
+			 Box yebx(Box(bx).grow(1).surroundingNodes(1));,
+			 Box zebx(Box(bx).grow(1).surroundingNodes(2)));
 
 #if (AMREX_SPACEDIM == 2)
-            Box xebx_g2(Box(bx).grow(1).grow(1,1).surroundingNodes(0));
-            Box yebx_g2(Box(bx).grow(1).grow(0,1).surroundingNodes(1));
+	    Box xebx_g2(Box(bx).grow(1).grow(1,1).surroundingNodes(0));
+	    Box yebx_g2(Box(bx).grow(1).grow(0,1).surroundingNodes(1));
 #else
-            Box xebx_g2(Box(bx).grow(1).grow(1,1).grow(2,1).surroundingNodes(0));
-            Box yebx_g2(Box(bx).grow(1).grow(0,1).grow(2,1).surroundingNodes(1));
-            Box zebx_g2(Box(bx).grow(1).grow(0,1).grow(1,1).surroundingNodes(2));
+	    Box xebx_g2(Box(bx).grow(1).grow(1,1).grow(2,1).surroundingNodes(0));
+	    Box yebx_g2(Box(bx).grow(1).grow(0,1).grow(2,1).surroundingNodes(1));
+	    Box zebx_g2(Box(bx).grow(1).grow(0,1).grow(1,1).surroundingNodes(2));
 #endif
+	    // FIXME? not sure if EB even needs the extra grow cell. Maybe it's a
+	    // leftover from when we did not use the FillPatch before Redistribution???
+// #if (AMREX_SPACEDIM == 2)
+// 		Box xebx_g2(Box(bx).grow(1,1).surroundingNodes(0));
+// 		Box yebx_g2(Box(bx).grow(0,1).surroundingNodes(1));
+// #else
+// 		Box xebx_g2(Box(bx).grow(1,1).grow(2,1).surroundingNodes(0));
+// 		Box yebx_g2(Box(bx).grow(0,1).grow(2,1).surroundingNodes(1));
+// 		Box zebx_g2(Box(bx).grow(0,1).grow(1,1).surroundingNodes(2));
+// #endif
 
-            Array4<Real> Imx = makeArray4(p,bxg2,ncomp);
-            p +=         Imx.size();
-            Array4<Real> Ipx = makeArray4(p,bxg2,ncomp);
-            p +=         Ipx.size();
-            Array4<Real> Imy = makeArray4(p,bxg2,ncomp);
-            p +=         Imy.size();
-            Array4<Real> Ipy = makeArray4(p,bxg2,ncomp);
-            p +=         Ipy.size();
+	    Box const& bxg2 = amrex::grow(bx,2);
 
-            Array4<Real> u_ad = makeArray4(p,xebx_g2,1);
-            p +=         u_ad.size();
-            Array4<Real> v_ad = makeArray4(p,yebx_g2,1);
-            p +=         v_ad.size();
+	    Array4<Real> Imx = makeArray4(p,bxg2,ncomp);
+	    p +=         Imx.size();
+	    Array4<Real> Ipx = makeArray4(p,bxg2,ncomp);
+	    p +=         Ipx.size();
+	    Array4<Real> Imy = makeArray4(p,bxg2,ncomp);
+	    p +=         Imy.size();
+	    Array4<Real> Ipy = makeArray4(p,bxg2,ncomp);
+	    p +=         Ipy.size();
+
+	    Array4<Real> u_ad = makeArray4(p,xebx_g2,1);
+	    p +=         u_ad.size();
+	    Array4<Real> v_ad = makeArray4(p,yebx_g2,1);
+	    p +=         v_ad.size();
 
 #if (AMREX_SPACEDIM == 3)
-            Array4<Real> Imz = makeArray4(p,bxg2,ncomp);
-            p +=         Imz.size();
-            Array4<Real> Ipz = makeArray4(p,bxg2,ncomp);
-            p +=         Ipz.size();
+	    Array4<Real> Imz = makeArray4(p,bxg2,ncomp);
+	    p +=         Imz.size();
+	    Array4<Real> Ipz = makeArray4(p,bxg2,ncomp);
+	    p +=         Ipz.size();
 
-            Array4<Real> w_ad = makeArray4(p,zebx_g2,1);
-            p +=         w_ad.size();
+	    Array4<Real> w_ad = makeArray4(p,zebx_g2,1);
+	    p +=         w_ad.size();
 #endif
 
             // This tests on covered cells just in the box itself
@@ -121,25 +135,38 @@ EBGodunov::ExtrapVelToFaces ( MultiFab const& vel,
             {
                 // We shouldn't need to zero these
 
-            // This tests on only regular cells including two rows of ghost cells
             }
-            else if (flagfab.getType(amrex::grow(bx,2)) == FabType::regular)
+            // Test includes 3 rows of ghost cells.
+	    // Godunov::ExtrapVelToFacesOnBox is callled on bx => need u_ad on
+	    // xebx_g1 (not xebx_g2 as in EB). Then need PredictVelOnXFace on
+	    // xebx_g1, which will call slopes on cell (i-1), slopes uses cell (i-1)-2
+	    // => check regular on grow 3
+            else if (flagfab.getType(amrex::grow(bx,3)) == FabType::regular)
             {
 
-                PLM::PredictVelOnXFace( xebx_g2, AMREX_SPACEDIM, Imx, Ipx, a_vel, a_vel,
-                                         geom, l_dt, h_bcrec, d_bcrec);
+#if (AMREX_SPACEDIM == 2)
+		Box xebx_g1(Box(bx).grow(1,1).surroundingNodes(0));
+		Box yebx_g1(Box(bx).grow(0,1).surroundingNodes(1));
+#else
+		Box xebx_g1(Box(bx).grow(1,1).grow(2,1).surroundingNodes(0));
+		Box yebx_g1(Box(bx).grow(0,1).grow(2,1).surroundingNodes(1));
+		Box zebx_g1(Box(bx).grow(0,1).grow(1,1).surroundingNodes(2));
+#endif
 
-                PLM::PredictVelOnYFace( yebx_g2, AMREX_SPACEDIM, Imy, Ipy, a_vel, a_vel,
+	        PLM::PredictVelOnXFace( xebx_g1, AMREX_SPACEDIM, Imx, Ipx, a_vel, a_vel,
+					geom, l_dt, h_bcrec, d_bcrec);
+
+                PLM::PredictVelOnYFace( yebx_g1, AMREX_SPACEDIM, Imy, Ipy, a_vel, a_vel,
                                         geom, l_dt, h_bcrec, d_bcrec);
 
 #if ( AMREX_SPACEDIM == 3 )
-                PLM::PredictVelOnZFace( zebx_g2, AMREX_SPACEDIM, Imz, Ipz, a_vel, a_vel,
+                PLM::PredictVelOnZFace( zebx_g1, AMREX_SPACEDIM, Imz, Ipz, a_vel, a_vel,
                                         geom, l_dt, h_bcrec, d_bcrec);
 #endif
 
 
                 bool local_use_forces_in_trans = false;
-                Godunov::ComputeAdvectiveVel( AMREX_D_DECL(Box(u_ad), Box(v_ad), Box(w_ad)),
+                Godunov::ComputeAdvectiveVel( AMREX_D_DECL(xebx_g1, yebx_g1, zebx_g1),
                                               AMREX_D_DECL(u_ad, v_ad, w_ad),
                                               AMREX_D_DECL(Imx, Imy, Imz),
                                               AMREX_D_DECL(Ipx, Ipy, Ipz),
@@ -255,7 +282,7 @@ EBGodunov::ComputeAdvectiveVel ( AMREX_D_DECL(Box const& xbx,
             Real st = ( (lo+hi) >= 0.) ? lo : hi;
             bool ltm = ( (lo <= 0. && hi >= 0.) || (amrex::Math::abs(lo+hi) < small_vel) );
             u_ad(i,j,k) = ltm ? 0. : st;
-        } else {
+	} else {
             u_ad(i,j,k) = 0.;
         }
     },

--- a/EBGodunov/hydro_ebgodunov_extrap_vel_to_faces_3D.cpp
+++ b/EBGodunov/hydro_ebgodunov_extrap_vel_to_faces_3D.cpp
@@ -54,21 +54,17 @@ EBGodunov::ExtrapVelToFacesOnBox ( Box const& bx, int ncomp,
     Real dy = dx_arr[1];
     Real dz = dx_arr[2];
 
-    Box xebx_g2 = Box(bx).grow(2).surroundingNodes(0);
-    Box yebx_g2 = Box(bx).grow(2).surroundingNodes(1);
-    Box zebx_g2 = Box(bx).grow(2).surroundingNodes(2);
-
-    Array4<Real> xlo = makeArray4(p, Box(xebx_g2), ncomp);
+    Array4<Real> xlo = makeArray4(p, Box(xebx), ncomp);
     p += xlo.size();
-    Array4<Real> xhi = makeArray4(p, Box(xebx_g2), ncomp);
+    Array4<Real> xhi = makeArray4(p, Box(xebx), ncomp);
     p += xhi.size();
-    Array4<Real> ylo = makeArray4(p, Box(yebx_g2), ncomp);
+    Array4<Real> ylo = makeArray4(p, Box(yebx), ncomp);
     p += ylo.size();
-    Array4<Real> yhi = makeArray4(p, Box(yebx_g2), ncomp);
+    Array4<Real> yhi = makeArray4(p, Box(yebx), ncomp);
     p += yhi.size();
-    Array4<Real> zlo = makeArray4(p, Box(zebx_g2), ncomp);
+    Array4<Real> zlo = makeArray4(p, Box(zebx), ncomp);
     p += zlo.size();
-    Array4<Real> zhi = makeArray4(p, Box(zebx_g2), ncomp);
+    Array4<Real> zhi = makeArray4(p, Box(zebx), ncomp);
     p += zhi.size();
 
     amrex::ParallelFor(

--- a/Utils/hydro_compute_fluxes_from_state.cpp
+++ b/Utils/hydro_compute_fluxes_from_state.cpp
@@ -50,7 +50,8 @@ HydroUtils::ComputeFluxesOnBoxFromState (
             if (flagfab.getType(bx) == FabType::covered)
                return;
 
-            bool regular = (flagfab.getType(amrex::grow(bx,2)) == FabType::regular);
+	    //FIXME? -- Godunov needs to check on grow 3, but MOL only needs 2
+            bool regular = (flagfab.getType(amrex::grow(bx,3)) == FabType::regular);
 
             if (!regular)
             {


### PR DESCRIPTION
This fixes some tiling issues seen in IAMR. And also cleans up the sizing of the scratch array in EBGodunov::ExtrapVelToFaces (which was oversized). 