### PR TITLE
Add a knownFaceState flag to the ComputeAdvFluxes.

### DIFF
--- a/Utils/hydro_utils.H
+++ b/Utils/hydro_utils.H
@@ -29,6 +29,7 @@ ComputeFluxesOnBoxFromState ( amrex::Box const& bx, int ncomp, amrex::MFIter& mf
                              AMREX_D_DECL(amrex::Array4<amrex::Real> const& xface,
                                           amrex::Array4<amrex::Real> const& yface,
                                           amrex::Array4<amrex::Real> const& zface),
+                             bool knownFaceState,
                              AMREX_D_DECL(amrex::Array4<amrex::Real const> const& umac,
                                           amrex::Array4<amrex::Real const> const& vmac,
                                           amrex::Array4<amrex::Real const> const& wmac),


### PR DESCRIPTION
Add a flag to ComputeFluxesOnBoxFromState to indicate whether or not the Face States need to be recomputed or are already good.