### PR TITLE
Replace RunOn::Host fir RunOn::Device in NodalProjector to prevent

### DIFF
--- a/Projections/hydro_NodalProjector.cpp
+++ b/Projections/hydro_NodalProjector.cpp
@@ -483,7 +483,7 @@ NodalProjector::setCoarseBoundaryVelocityForSync ()
                     Box ovlp = *it & v_fab.box();
                     if (ovlp.ok())
                     {
-                        v_fab.setVal<RunOn::Host>(0.0, ovlp, idir, 1);
+                        v_fab.setVal<RunOn::Device>(0.0, ovlp, idir, 1);
                     }
                 }
             }


### PR DESCRIPTION
failure when running with the_arena_is_managed = 0.