### PR TITLE
Fix unused variable warnings

### DIFF
--- a/EBGodunov/hydro_ebgodunov_edge_state_3D.cpp
+++ b/EBGodunov/hydro_ebgodunov_edge_state_3D.cpp
@@ -52,10 +52,6 @@ EBGodunov::ComputeEdgeState ( Box const& bx, int ncomp,
     Box yebx = Box(ybx).grow(0,1).grow(2,1);
     Box zebx = Box(zbx).grow(0,1).grow(1,1);
 
-    Box xebx_g2(Box(bx).grow(1).grow(1,1).grow(2,1).surroundingNodes(0));
-    Box yebx_g2(Box(bx).grow(1).grow(0,1).grow(2,1).surroundingNodes(1));
-    Box zebx_g2(Box(bx).grow(1).grow(0,1).grow(1,1).surroundingNodes(2));
-
     Box const& bxg2 = amrex::grow(bx,2);
 
     const Real dx = geom.CellSize(0);


### PR DESCRIPTION
With Clang 12 with -Wall -Wextra:
```
/builds/gitlab/exa/mfix/subprojects/AMReX-Hydro/EBGodunov/hydro_ebgodunov_edge_state_3D.cpp:57:9: error: unused variable 'zebx_g2' [-Werror,-Wunused-variable]
    Box zebx_g2(Box(bx).grow(1).grow(0,1).grow(1,1).surroundingNodes(2));
        ^
/builds/gitlab/exa/mfix/subprojects/AMReX-Hydro/EBGodunov/hydro_ebgodunov_edge_state_3D.cpp:55:9: error: unused variable 'xebx_g2' [-Werror,-Wunused-variable]
    Box xebx_g2(Box(bx).grow(1).grow(1,1).grow(2,1).surroundingNodes(0));
        ^
/builds/gitlab/exa/mfix/subprojects/AMReX-Hydro/EBGodunov/hydro_ebgodunov_edge_state_3D.cpp:56:9: error: unused variable 'yebx_g2' [-Werror,-Wunused-variable]
    Box yebx_g2(Box(bx).grow(1).grow(0,1).grow(2,1).surroundingNodes(1));
        ^
3 errors generated.
```