### PR TITLE
Link AMReX Doxygen docs via tagfile

### DIFF
--- a/Docs/Doxygen/doxygen.conf
+++ b/Docs/Doxygen/doxygen.conf
@@ -2213,7 +2213,7 @@ SKIP_FUNCTION_MACROS   = NO
 # the path). If a tag file is not located in the directory in which doxygen is
 # run, you must also specify the path to the tagfile here.
 
-TAGFILES               =
+TAGFILES               = amrex-doxygen-web.tag.xml=https://amrex-codes.github.io/amrex/doxygen
 
 # When a file name is specified after GENERATE_TAGFILE, doxygen will create a
 # tag file that is based on the input files it reads. See section "Linking to

--- a/build_doxygen_docs.sh
+++ b/build_doxygen_docs.sh
@@ -2,7 +2,12 @@
 set -e # Exit with nonzero exit code if anything fails
 
 # Doxygen
-echo "Build the Doxygen documentation"
+echo "Building the Doxygen documentation"
+
+# Get AMReX Doxygen Tagfile
+wget https://amrex-codes.github.io/amrex/docs_xml/doxygen/amrex-doxygen-web.tag.xml -O amrex-doxygen-web.tag.xml
+
+# Render HTML Docs
 doxygen ./Docs/Doxygen/doxygen.conf &> doxygen.out
 
 


### PR DESCRIPTION
This links the AMReX-Hydro Doxygen Docs to the AMReX Doxygen Docs for libraries, variable types, etc. 