### PR TITLE
Slope reg tests

### DIFF
--- a/Tests/Slopes/RegTest-AskewYZ.sh
+++ b/Tests/Slopes/RegTest-AskewYZ.sh
@@ -1,5 +1,0 @@
-#! /bin/bash
-
-./main3d.gnu.TEST.MPI.ex ./inputs.3d.linear.askew-yz 
-
-fcompare plot-3d-askew-yz/ plot-3d-askew-yz-analytic/

--- a/Tests/Slopes/RegTest-AskewYZ.sh
+++ b/Tests/Slopes/RegTest-AskewYZ.sh
@@ -1,0 +1,5 @@
+#! /bin/bash
+
+./main3d.gnu.TEST.MPI.ex ./inputs.3d.linear.askew-yz 
+
+fcompare plot-3d-askew-yz/ plot-3d-askew-yz-analytic/

--- a/Tests/Slopes/inputs.3d.linear.askew-xz
+++ b/Tests/Slopes/inputs.3d.linear.askew-xz
@@ -12,7 +12,7 @@ eb2.channel_has_fluid_inside = 1
 
 max_level = 0
 #ref_ratio = 2
-n_cell = 20
+n_cell = 64
 max_grid_size = 64
 #max_coarsening_level = 0
 prob_lo = 0.   0.   0.


### PR DESCRIPTION
The small number of cells used in the `inputs.3d.linear.askew-xz` caused an error because the specified geometry was too close to the periodic boundary. More consideration is needed for a more robust solution. In the meantime increasing the number of cells in the test avoids the issue. 