### PR TITLE
Cuda slope test fix

### DIFF
--- a/Tests/Slopes/MyTest.H
+++ b/Tests/Slopes/MyTest.H
@@ -16,6 +16,9 @@ public:
     void writePlotfile ();
     void initData ();
 
+    void initializeLinearDataFor2D (int ilev);
+    void initializeLinearDataFor3D (int ilev);
+
 private:
 
     void initializeEB ();
@@ -23,8 +26,6 @@ private:
     void initGrids ();
 
     void initializeLinearData (int ilev);
-    void initializeLinearDataFor2D (int ilev);
-    void initializeLinearDataFor3D (int ilev);
 
     int max_level = 0;
     int ref_ratio = 2;


### PR DESCRIPTION
I noticed the CUDA regression tests were failing. The projection tests have low absolute error but the slope tests were failing to compile. So far I was able to get the 3D test to compile with `USE_CUDA=TRUE` however there is still a runtime error to sort out. 