### PR TITLE
fix a typo bug in EB_ComputeDivergence

### DIFF
--- a/Utils/hydro_utils.cpp
+++ b/Utils/hydro_utils.cpp
@@ -259,7 +259,7 @@ HydroUtils::EB_ComputeDivergence ( Box const& bx,
                              (fx(i+1,j,k,n) -  fx(i,j,k,n)) * dxinv[0]
                            + (fy(i,j+1,k,n) -  fy(i,j,k,n)) * dxinv[1]
 #if (AMREX_SPACEDIM==3)
-                           + (fz(i,j,k+1,n) -  fz(i,j,k,n)) * dxinv[1]
+                           + (fz(i,j,k+1,n) -  fz(i,j,k,n)) * dxinv[2]
 #endif
                     );
         }


### PR DESCRIPTION
this looks to me like the index should be "2" not "1"