### PR TITLE
add BDS folder to doxygen input directories

### DIFF
--- a/Docs/Doxygen/doxygen.conf
+++ b/Docs/Doxygen/doxygen.conf
@@ -864,7 +864,7 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = ./EBMOL ./EBGodunov ./MOL ./Godunov ./Projections ./Utils ./Redistribution ./Docs/Doxygen/main.dox
+INPUT                  = ./EBMOL ./EBGodunov ./MOL ./Godunov ./Projections ./Utils ./Redistribution ./Docs/Doxygen/main.dox ./BDS
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses


### PR DESCRIPTION
Have doxygen parse the BDS directory to generate the automated documentation. 