### PR TITLE
Add version check to avoid error message

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,11 @@ endif ()
 
 if (HYDRO_GPU_BACKEND STREQUAL "CUDA")
    enable_language(CUDA)
-   find_package(CUDAToolkit REQUIRED)
+
+   if (CMAKE_VERSION GREATER_THAN 3.17)
+      #The CUDAToolkit was added with version 3.17
+      find_package(CUDAToolkit REQUIRED)
+   endif()
 endif ()
 
 #


### PR DESCRIPTION
Check for CMake ver >=3.17 before using the `find_package(CUDAToolkit)` functionality. 