### PR TITLE
Cmake cuda ver fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,11 @@ endif ()
 
 if (HYDRO_GPU_BACKEND STREQUAL "CUDA")
    enable_language(CUDA)
-   find_package(CUDAToolkit REQUIRED)
+
+   if (CMAKE_VERSION GREATER_THAN 3.17)
+      #The CUDAToolkit was added with version 3.17
+      find_package(CUDAToolkit REQUIRED)
+   endif()
 endif ()
 
 #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ endif ()
 if (HYDRO_GPU_BACKEND STREQUAL "CUDA")
    enable_language(CUDA)
 
-   if (CMAKE_VERSION GREATER_THAN 3.17)
+   if (CMAKE_VERSION GREATER_EQUAL 3.17)
       #The CUDAToolkit was added with version 3.17
       find_package(CUDAToolkit REQUIRED)
    endif()


### PR DESCRIPTION
Check for CMake ver >=3.17 before using the find_package(CUDAToolkit) functionality. Also, I think some changes to AMReX's cmake fixed whatever was causing the CI to fail before. 

Moved PR# https://github.com/AMReX-Codes/AMReX-Hydro/pull/87  because I pushed from the wrong branch. 