### PR TITLE
fix compilation warning

### DIFF
--- a/MOL/hydro_mol_extrap_vel_to_faces_box.cpp
+++ b/MOL/hydro_mol_extrap_vel_to_faces_box.cpp
@@ -345,7 +345,6 @@ MOL::ExtrapVelToFacesBox (  AMREX_D_DECL( Box const& ubx,
         AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
             constexpr int     n = 2;
-            constexpr int order = 2;
 
             Real wpls = vcc(i,j,k  ,2) - 0.5 * amrex_calc_zslope(i,j,k  ,2,order,vcc);
             Real wmns = vcc(i,j,k-1,2) + 0.5 * amrex_calc_zslope(i,j,k-1,2,order,vcc);


### PR DESCRIPTION
this MR fixes a compilation warning due to the local declaration of variable 'order' which shadows a previous local variable