### PR TITLE
Enable symmetry and hoextraptocc-based boundary conditions

### DIFF
--- a/BDS/hydro_bds_edge_state_2D.cpp
+++ b/BDS/hydro_bds_edge_state_2D.cpp
@@ -105,13 +105,8 @@ BDS::ComputeSlopes ( Box const& bx,
 
     auto bc = pbc[icomp];
 
-    // Abort for cell-centered BC types
-    if ( bc.lo(0) == BCType::reflect_even || bc.lo(0) == BCType::reflect_odd || bc.lo(0) == BCType::hoextrapcc ||
-         bc.hi(0) == BCType::reflect_even || bc.hi(0) == BCType::reflect_odd || bc.hi(0) == BCType::hoextrapcc ||
-         bc.lo(1) == BCType::reflect_even || bc.lo(1) == BCType::reflect_odd || bc.lo(1) == BCType::hoextrapcc ||
-         bc.hi(1) == BCType::reflect_even || bc.hi(1) == BCType::reflect_odd || bc.hi(1) == BCType::hoextrapcc )
-        amrex::Abort("BDS::Slopes: Unsupported BC type. Supported types are int_dir, ext_dir, foextrap, and hoextrap");
-
+    // these are the BC types where the first ghost cell represents the value ON the boundary
+    // for reflect_even, reflect_odd, and hoextrapcc, all the ghost cells are filled in with values extrapolated to the cell centers
     bool lo_x_physbc = (bc.lo(0) == BCType::foextrap || bc.lo(0) == BCType::hoextrap || bc.lo(0) == BCType::ext_dir) ? true : false;
     bool hi_x_physbc = (bc.hi(0) == BCType::foextrap || bc.hi(0) == BCType::hoextrap || bc.hi(0) == BCType::ext_dir) ? true : false;
     bool lo_y_physbc = (bc.lo(1) == BCType::foextrap || bc.lo(1) == BCType::hoextrap || bc.lo(1) == BCType::ext_dir) ? true : false;
@@ -140,7 +135,7 @@ BDS::ComputeSlopes ( Box const& bx,
             return;
         }
 
-        // one cell inward from any physical boundary, revert to 4-point average
+        // one cell inward from any boundary where the ghost cells represents the value ON the boundary, revert to 4-point average
         if ( (i==dlo.x+1 && lo_x_physbc) ||
              (i==dhi.x   && hi_x_physbc) ||
              (j==dlo.y+1 && lo_y_physbc) ||

--- a/BDS/hydro_bds_edge_state_3D.cpp
+++ b/BDS/hydro_bds_edge_state_3D.cpp
@@ -115,15 +115,8 @@ BDS::ComputeSlopes ( Box const& bx,
 
     auto bc = pbc[icomp];
 
-    // Abort for cell-centered BC types
-    if ( bc.lo(0) == BCType::reflect_even || bc.lo(0) == BCType::reflect_odd || bc.lo(0) == BCType::hoextrapcc ||
-         bc.hi(0) == BCType::reflect_even || bc.hi(0) == BCType::reflect_odd || bc.hi(0) == BCType::hoextrapcc ||
-         bc.lo(1) == BCType::reflect_even || bc.lo(1) == BCType::reflect_odd || bc.lo(1) == BCType::hoextrapcc ||
-         bc.hi(1) == BCType::reflect_even || bc.hi(1) == BCType::reflect_odd || bc.hi(1) == BCType::hoextrapcc ||
-         bc.lo(2) == BCType::reflect_even || bc.lo(2) == BCType::reflect_odd || bc.lo(2) == BCType::hoextrapcc ||
-         bc.hi(2) == BCType::reflect_even || bc.hi(2) == BCType::reflect_odd || bc.hi(2) == BCType::hoextrapcc )
-        amrex::Abort("BDS::Slopes: Unsupported BC type. Supported types are int_dir, ext_dir, foextrap, and hoextrap");
-
+    // these are the BC types where the first ghost cell represents the value ON the boundary
+    // for reflect_even, reflect_odd, and hoextrapcc, all the ghost cells are filled in with values extrapolated to the cell centers
     bool lo_x_physbc = (bc.lo(0) == BCType::foextrap || bc.lo(0) == BCType::hoextrap || bc.lo(0) == BCType::ext_dir) ? true : false;
     bool hi_x_physbc = (bc.hi(0) == BCType::foextrap || bc.hi(0) == BCType::hoextrap || bc.hi(0) == BCType::ext_dir) ? true : false;
     bool lo_y_physbc = (bc.lo(1) == BCType::foextrap || bc.lo(1) == BCType::hoextrap || bc.lo(1) == BCType::ext_dir) ? true : false;
@@ -161,7 +154,7 @@ BDS::ComputeSlopes ( Box const& bx,
             return;
         }
 
-        // one cell inward from any physical boundary, revert to 8-point average
+        // one cell inward from any boundary where the ghost cells represents the value ON the boundary, revert to 8-point average
         if ( (i==dlo.x+1 && lo_x_physbc) ||
              (i==dhi.x   && hi_x_physbc) ||
              (j==dlo.y+1 && lo_y_physbc) ||


### PR DESCRIPTION
Address Issue #96 

There are 2 classes of physical of boundary conditions - those that store the value ON the boundary in the first ghost cell, and those that fill ALL the ghost cells with values extrapolated to those cell-centers.

The latter case should "Just work", e.g., symmetry and hoextraptocc, so I removed the Abort in those cases.

For the former case I previously was careful to make sure that interpolated values to the actual boundary in the BDS algorithm respected the boundary value that was stored in the ghost cell.