### PR TITLE
Fix host access of device pointer in BDS

### DIFF
--- a/BDS/hydro_bds.H
+++ b/BDS/hydro_bds.H
@@ -67,7 +67,6 @@ void ComputeEdgeState ( amrex::Box const& bx, int ncomp,
  * \param [in]  s       Array4<const> of state vector.
  * \param [out] slopes  Array4 to store slope information.
  * \param [in]  h_bcrec Boundary conditions (host).
- * \param [in]  pbc     Boundary conditions (device).
  *
  */
 
@@ -76,8 +75,7 @@ void ComputeSlopes ( amrex::Box const& bx,
                      int icomp,
                      amrex::Array4<amrex::Real const> const& s,
                      amrex::Array4<amrex::Real      > const& slopes,
-                     amrex::Vector<amrex::BCRec> const& h_bcrec,
-                     amrex::BCRec const* pbc);
+                     amrex::Vector<amrex::BCRec> const& h_bcrec);
 
 /**
  * Compute Conc for BDS algorithm.

--- a/BDS/hydro_bds.H
+++ b/BDS/hydro_bds.H
@@ -33,6 +33,8 @@ namespace BDS {
  * \param [in]     fq          Array4 for forces, starting at component of interest
  * \param [in]     geom        Level geometry.
  * \param [in]     l_dt        Time step.
+ * \param [in]     h_bcrec     Boundary conditions (host).
+ * \param [in]     pbc         Boundary conditions (device).
  * \param [in]     iconserv    If true, use conservative form, otherwise use convective.
  * \param [in]     is_velocity Indicates a component is velocity so boundary conditions can
  *                             be properly addressed. The header hydro_constants.H
@@ -51,6 +53,7 @@ void ComputeEdgeState ( amrex::Box const& bx, int ncomp,
                         amrex::Array4<amrex::Real const> const& fq,
                         amrex::Geometry geom,
                         amrex::Real l_dt,
+                        amrex::Vector<amrex::BCRec> const& h_bcrec,
                         amrex::BCRec const* pbc,
                         int const* iconserv,
                         const bool is_velocity);
@@ -63,6 +66,8 @@ void ComputeEdgeState ( amrex::Box const& bx, int ncomp,
  * \param [in]  icomp   Component of the state Array4.
  * \param [in]  s       Array4<const> of state vector.
  * \param [out] slopes  Array4 to store slope information.
+ * \param [in]  h_bcrec Boundary conditions (host).
+ * \param [in]  pbc     Boundary conditions (device).
  *
  */
 
@@ -71,6 +76,7 @@ void ComputeSlopes ( amrex::Box const& bx,
                      int icomp,
                      amrex::Array4<amrex::Real const> const& s,
                      amrex::Array4<amrex::Real      > const& slopes,
+                     amrex::Vector<amrex::BCRec> const& h_bcrec,
                      amrex::BCRec const* pbc);
 
 /**
@@ -90,6 +96,8 @@ void ComputeSlopes ( amrex::Box const& bx,
  * \param [in]     force       Array4 for forces.
  * \param [in]     iconserv    If true, use conservative form, otherwise use convective.
  * \param [in]     dt          Time step.
+ * \param [in]     h_bcrec     Boundary conditions (host).
+ * \param [in]     pbc         Boundary conditions (device).
  * \param [in]     is_velocity Indicates a component is velocity so boundary conditions can
  *                             be properly addressed. The header hydro_constants.H
  *                             defines the component positon by [XYZ]VEL macro.
@@ -112,6 +120,7 @@ void ComputeConc ( amrex::Box const& bx,
                    amrex::Array4<amrex::Real const> const& force,
                    int const* iconserv,
                    const amrex::Real dt,
+                   amrex::Vector<amrex::BCRec> const& h_bcrec,
                    amrex::BCRec const* pbc,
                    const bool is_velocity);
 

--- a/BDS/hydro_bds_edge_state_3D.cpp
+++ b/BDS/hydro_bds_edge_state_3D.cpp
@@ -121,7 +121,7 @@ BDS::ComputeSlopes ( Box const& bx,
     const auto dlo = amrex::lbound(domain);
     const auto dhi = amrex::ubound(domain);
 
-    auto bc = pbc[icomp];
+    auto bc = h_bcrec.data()[icomp];
 
     // these are the BC types where the first ghost cell represents the value ON the boundary
     // for reflect_even, reflect_odd, and hoextrapcc, all the ghost cells are filled in with values extrapolated to the cell centers
@@ -585,7 +585,7 @@ BDS::ComputeConc (Box const& bx,
     const auto dlo = amrex::lbound(domain);
     const auto dhi = amrex::ubound(domain);
 
-    auto bc = pbc[icomp];
+    auto bc = h_bcrec.data()[icomp];
     bool lo_x_physbc = (bc.lo(0) == BCType::foextrap || bc.lo(0) == BCType::hoextrap || bc.lo(0) == BCType::ext_dir) ? true : false;
     bool hi_x_physbc = (bc.hi(0) == BCType::foextrap || bc.hi(0) == BCType::hoextrap || bc.hi(0) == BCType::ext_dir) ? true : false;
     bool lo_y_physbc = (bc.lo(1) == BCType::foextrap || bc.lo(1) == BCType::hoextrap || bc.lo(1) == BCType::ext_dir) ? true : false;

--- a/BDS/hydro_bds_edge_state_3D.cpp
+++ b/BDS/hydro_bds_edge_state_3D.cpp
@@ -29,6 +29,8 @@ constexpr amrex::Real eps = 1.0e-8;
  * \param [in]     fq          Array4 for forces, starting at component of interest
  * \param [in]     geom        Level geometry.
  * \param [in]     l_dt        Time step.
+ * \param [in]     h_bcrec     Boundary conditions (host).
+ * \param [in]     pbc         Boundary conditions (device).
  * \param [in]     iconserv    Indicates conservative dimensions.
  * \param [in]     is_velocity Indicates a component is velocity so boundary conditions can
  *                             be properly addressed. The header hydro_constants.H
@@ -48,7 +50,9 @@ BDS::ComputeEdgeState ( Box const& bx, int ncomp,
                         Array4<Real const> const& fq,
                         Geometry geom,
                         Real l_dt,
-                        BCRec const* pbc, int const* iconserv,
+                        Vector<BCRec> const& h_bcrec,
+                        BCRec const* pbc,
+                        int const* iconserv,
                         const bool is_velocity)
 {
     // For now, loop on components here
@@ -60,14 +64,15 @@ BDS::ComputeEdgeState ( Box const& bx, int ncomp,
 
         BDS::ComputeSlopes(bx, geom, icomp,
                            q, slopefab.array(),
-                           pbc);
+                           h_bcrec, pbc);
 
         BDS::ComputeConc(bx, geom, icomp,
                          q, xedge, yedge, zedge,
                          slopefab.array(),
                          umac, vmac, wmac, divu, fq,
                          iconserv,
-                         l_dt, pbc, is_velocity);
+                         l_dt, h_bcrec, pbc,
+                         is_velocity);
     }
 }
 
@@ -79,6 +84,8 @@ BDS::ComputeEdgeState ( Box const& bx, int ncomp,
  * \param [in]  icomp   Component of the state Array4.
  * \param [in]  s       Array4<const> of state vector.
  * \param [out] slopes  Array4 to store slope information.
+ * \param [in]  h_bcrec Boundary conditions (host).
+ * \param [in]  pbc     Boundary conditions (device).
  *
  */
 
@@ -88,6 +95,7 @@ BDS::ComputeSlopes ( Box const& bx,
                      int icomp,
                      Array4<Real const> const& s,
                      Array4<Real      > const& slopes,
+                     Vector<BCRec> const& h_bcrec,
                      BCRec const* pbc)
 {
     constexpr bool limit_slopes = true;
@@ -524,6 +532,8 @@ Real eval (const Real s,
  * \param [in]     force       Array4 for forces.
  * \param [in]     iconserv    Indicates conservative dimensions.
  * \param [in]     dt          Time step.
+ * \param [in]     h_bcrec     Boundary conditions (host).
+ * \param [in]     pbc         Boundary conditions (device).
  * \param [in]     is_velocity Indicates a component is velocity so boundary conditions can
  *                             be properly addressed. The header hydro_constants.H
  *                             defines the component positon by [XYZ]VEL macro.
@@ -546,7 +556,9 @@ BDS::ComputeConc (Box const& bx,
                   Array4<Real const> const& divu,
                   Array4<Real const> const& force,
                   int const* iconserv,
-                  const Real dt, BCRec const* pbc,
+                  const Real dt,
+                  Vector<BCRec> const& h_bcrec,
+                  BCRec const* pbc,
                   const bool is_velocity)
 {
     Box const& gbx = amrex::grow(bx,1);

--- a/BDS/hydro_bds_edge_state_3D.cpp
+++ b/BDS/hydro_bds_edge_state_3D.cpp
@@ -64,7 +64,7 @@ BDS::ComputeEdgeState ( Box const& bx, int ncomp,
 
         BDS::ComputeSlopes(bx, geom, icomp,
                            q, slopefab.array(),
-                           h_bcrec, pbc);
+                           h_bcrec);
 
         BDS::ComputeConc(bx, geom, icomp,
                          q, xedge, yedge, zedge,
@@ -85,7 +85,6 @@ BDS::ComputeEdgeState ( Box const& bx, int ncomp,
  * \param [in]  s       Array4<const> of state vector.
  * \param [out] slopes  Array4 to store slope information.
  * \param [in]  h_bcrec Boundary conditions (host).
- * \param [in]  pbc     Boundary conditions (device).
  *
  */
 
@@ -95,8 +94,7 @@ BDS::ComputeSlopes ( Box const& bx,
                      int icomp,
                      Array4<Real const> const& s,
                      Array4<Real      > const& slopes,
-                     Vector<BCRec> const& h_bcrec,
-                     BCRec const* pbc)
+                     Vector<BCRec> const& h_bcrec)
 {
     constexpr bool limit_slopes = true;
 
@@ -121,16 +119,16 @@ BDS::ComputeSlopes ( Box const& bx,
     const auto dlo = amrex::lbound(domain);
     const auto dhi = amrex::ubound(domain);
 
-    auto bc = h_bcrec.data()[icomp];
+    auto h_bc = h_bcrec.data()[icomp];
 
     // these are the BC types where the first ghost cell represents the value ON the boundary
     // for reflect_even, reflect_odd, and hoextrapcc, all the ghost cells are filled in with values extrapolated to the cell centers
-    bool lo_x_physbc = (bc.lo(0) == BCType::foextrap || bc.lo(0) == BCType::hoextrap || bc.lo(0) == BCType::ext_dir) ? true : false;
-    bool hi_x_physbc = (bc.hi(0) == BCType::foextrap || bc.hi(0) == BCType::hoextrap || bc.hi(0) == BCType::ext_dir) ? true : false;
-    bool lo_y_physbc = (bc.lo(1) == BCType::foextrap || bc.lo(1) == BCType::hoextrap || bc.lo(1) == BCType::ext_dir) ? true : false;
-    bool hi_y_physbc = (bc.hi(1) == BCType::foextrap || bc.hi(1) == BCType::hoextrap || bc.hi(1) == BCType::ext_dir) ? true : false;
-    bool lo_z_physbc = (bc.lo(2) == BCType::foextrap || bc.lo(2) == BCType::hoextrap || bc.lo(2) == BCType::ext_dir) ? true : false;
-    bool hi_z_physbc = (bc.hi(2) == BCType::foextrap || bc.hi(2) == BCType::hoextrap || bc.hi(2) == BCType::ext_dir) ? true : false;
+    bool lo_x_physbc = (h_bc.lo(0) == BCType::foextrap || h_bc.lo(0) == BCType::hoextrap || h_bc.lo(0) == BCType::ext_dir) ? true : false;
+    bool hi_x_physbc = (h_bc.hi(0) == BCType::foextrap || h_bc.hi(0) == BCType::hoextrap || h_bc.hi(0) == BCType::ext_dir) ? true : false;
+    bool lo_y_physbc = (h_bc.lo(1) == BCType::foextrap || h_bc.lo(1) == BCType::hoextrap || h_bc.lo(1) == BCType::ext_dir) ? true : false;
+    bool hi_y_physbc = (h_bc.hi(1) == BCType::foextrap || h_bc.hi(1) == BCType::hoextrap || h_bc.hi(1) == BCType::ext_dir) ? true : false;
+    bool lo_z_physbc = (h_bc.lo(2) == BCType::foextrap || h_bc.lo(2) == BCType::hoextrap || h_bc.lo(2) == BCType::ext_dir) ? true : false;
+    bool hi_z_physbc = (h_bc.hi(2) == BCType::foextrap || h_bc.hi(2) == BCType::hoextrap || h_bc.hi(2) == BCType::ext_dir) ? true : false;
 
     // tricubic interpolation to corner points
     // (i,j,k) refers to lower corner of cell
@@ -585,13 +583,13 @@ BDS::ComputeConc (Box const& bx,
     const auto dlo = amrex::lbound(domain);
     const auto dhi = amrex::ubound(domain);
 
-    auto bc = h_bcrec.data()[icomp];
-    bool lo_x_physbc = (bc.lo(0) == BCType::foextrap || bc.lo(0) == BCType::hoextrap || bc.lo(0) == BCType::ext_dir) ? true : false;
-    bool hi_x_physbc = (bc.hi(0) == BCType::foextrap || bc.hi(0) == BCType::hoextrap || bc.hi(0) == BCType::ext_dir) ? true : false;
-    bool lo_y_physbc = (bc.lo(1) == BCType::foextrap || bc.lo(1) == BCType::hoextrap || bc.lo(1) == BCType::ext_dir) ? true : false;
-    bool hi_y_physbc = (bc.hi(1) == BCType::foextrap || bc.hi(1) == BCType::hoextrap || bc.hi(1) == BCType::ext_dir) ? true : false;
-    bool lo_z_physbc = (bc.lo(2) == BCType::foextrap || bc.lo(2) == BCType::hoextrap || bc.lo(2) == BCType::ext_dir) ? true : false;
-    bool hi_z_physbc = (bc.hi(2) == BCType::foextrap || bc.hi(2) == BCType::hoextrap || bc.hi(2) == BCType::ext_dir) ? true : false;
+    auto h_bc = h_bcrec.data()[icomp];
+    bool lo_x_physbc = (h_bc.lo(0) == BCType::foextrap || h_bc.lo(0) == BCType::hoextrap || h_bc.lo(0) == BCType::ext_dir) ? true : false;
+    bool hi_x_physbc = (h_bc.hi(0) == BCType::foextrap || h_bc.hi(0) == BCType::hoextrap || h_bc.hi(0) == BCType::ext_dir) ? true : false;
+    bool lo_y_physbc = (h_bc.lo(1) == BCType::foextrap || h_bc.lo(1) == BCType::hoextrap || h_bc.lo(1) == BCType::ext_dir) ? true : false;
+    bool hi_y_physbc = (h_bc.hi(1) == BCType::foextrap || h_bc.hi(1) == BCType::hoextrap || h_bc.hi(1) == BCType::ext_dir) ? true : false;
+    bool lo_z_physbc = (h_bc.lo(2) == BCType::foextrap || h_bc.lo(2) == BCType::hoextrap || h_bc.lo(2) == BCType::ext_dir) ? true : false;
+    bool hi_z_physbc = (h_bc.hi(2) == BCType::foextrap || h_bc.hi(2) == BCType::hoextrap || h_bc.hi(2) == BCType::ext_dir) ? true : false;
 
     ParallelFor(gbx, [=] AMREX_GPU_DEVICE (int i, int j, int k){
           ux(i,j,k) = (umac(i+1,j,k) - umac(i,j,k)) / hx;
@@ -602,6 +600,8 @@ BDS::ComputeConc (Box const& bx,
     // compute sedgex on x-faces
     Box const& xbx = amrex::surroundingNodes(bx,0);
     ParallelFor(xbx, [=] AMREX_GPU_DEVICE (int i, int j, int k){
+
+        auto bc = pbc[icomp];
 
         // set edge values equal to the ghost cell value since they store the physical condition on the boundary
         if ( i==dlo.x && lo_x_physbc ) {
@@ -1568,6 +1568,8 @@ BDS::ComputeConc (Box const& bx,
     Box const& ybx = amrex::surroundingNodes(bx,1);
     ParallelFor(ybx, [=] AMREX_GPU_DEVICE (int i, int j, int k){
 
+        auto bc = pbc[icomp];
+
         // set edge values equal to the ghost cell value since they store the physical condition on the boundary
         if ( j==dlo.y && lo_y_physbc ) {
             sedgey(i,j,k,icomp) = s(i,j-1,k,icomp);
@@ -2527,6 +2529,8 @@ BDS::ComputeConc (Box const& bx,
     // compute sedgez on z-faces
     Box const& zbx = amrex::surroundingNodes(bx,2);
     ParallelFor(zbx, [=] AMREX_GPU_DEVICE (int i, int j, int k){
+
+        auto bc = pbc[icomp];
 
         // set edge values equal to the ghost cell value since they store the physical condition on the boundary
         if ( k==dlo.z && lo_z_physbc ) {

--- a/Utils/hydro_compute_edgestate_and_flux.cpp
+++ b/Utils/hydro_compute_edgestate_and_flux.cpp
@@ -130,8 +130,8 @@ namespace {
                                        AMREX_D_DECL(face_x,face_y,face_z),
                                        AMREX_D_DECL(u_mac,v_mac,w_mac),
                                        divu, fq, geom,
-                                       l_dt, d_bcrec, iconserv,
-                                       is_velocity);
+                                       l_dt, h_bcrec, d_bcrec,
+                                       iconserv, is_velocity);
             }
             else
             {


### PR DESCRIPTION
The host accesses the BC device pointer in BDS. This is fine if `amrex.the_arena_is_managed=1` but not when `amrex.the_arena_is_managed=0`. This PR passes the host data through and accesses that instead. 

The BC device pointer data is kept but it isn't used anymore. I kept it in case someone ever wanted to access the BCs on device in BDS later but I am happy to remove as well.