### PR TITLE
Add support for mixed bcs in (EB)godunov PLM and MacProjector

### DIFF
--- a/EBGodunov/hydro_ebgodunov.H
+++ b/EBGodunov/hydro_ebgodunov.H
@@ -23,7 +23,9 @@ namespace EBGodunov {
                             amrex::Vector<amrex::BCRec> const& h_bcrec,
                             amrex::BCRec  const* d_bcrec,
                             const amrex::Geometry& geom,
-                            amrex::Real dt, amrex::MultiFab const* velocity_on_eb_inflow = nullptr);
+                            amrex::Real dt,
+                            amrex::MultiFab const* velocity_on_eb_inflow = nullptr,
+                            amrex::iMultiFab const* BC_MF = nullptr);
 
 
     void ComputeAdvectiveVel (AMREX_D_DECL(amrex::Box const& xbx,
@@ -41,7 +43,8 @@ namespace EBGodunov {
                               amrex::Array4<amrex::Real const> const& vel,
                               amrex::Array4<amrex::EBCellFlag const> const& flag,
                               const amrex::Box& domain,
-                              amrex::BCRec const* pbc);
+                              amrex::BCRec const* pbc,
+                              amrex::Array4<int const> const& bc_arr = {});
 
     void ExtrapVelToFacesOnBox ( amrex::Box const& bx, int ncomp,
                                  AMREX_D_DECL(amrex::Box const& xbx,
@@ -78,7 +81,8 @@ namespace EBGodunov {
                                  AMREX_D_DECL(amrex::Array4<amrex::Real const> const& fcx,
                                               amrex::Array4<amrex::Real const> const& fcy,
                                               amrex::Array4<amrex::Real const> const& fcz),
-                                 amrex::Real* p, amrex::Array4<amrex::Real const> const& velocity_on_eb_inflow);
+                                 amrex::Real* p, amrex::Array4<amrex::Real const> const& velocity_on_eb_inflow,
+                                 amrex::Array4<int const> const& bc_arr = {});
 
 
     void ComputeEdgeState ( amrex::Box const& bx, int ncomp,
@@ -107,7 +111,8 @@ namespace EBGodunov {
                                          amrex::Array4<amrex::Real const> const& fcz),
                             amrex::Array4<amrex::Real const> const& ccent_arr,
                             bool is_velocity,
-                            amrex::Array4<amrex::Real const> const& values_on_eb_inflow);
+                            amrex::Array4<amrex::Real const> const& values_on_eb_inflow,
+                            amrex::Array4<int const> const& bc_arr = {});
 
 } // namespace ebgodunov
 

--- a/EBGodunov/hydro_ebgodunov_bcs_K.H
+++ b/EBGodunov/hydro_ebgodunov_bcs_K.H
@@ -29,7 +29,8 @@ void SetXBCs (const int i, const int j, const int k, const int n,
               amrex::Real &hi,
               const int bclo, const int bchi,
               const int domlo, const int domhi,
-              const bool is_velocity )
+              const bool is_velocity,
+              const amrex::Array4<const int> const& bc_arr = {})
 {
     using namespace amrex;
 
@@ -37,7 +38,9 @@ void SetXBCs (const int i, const int j, const int k, const int n,
     // Low X
     if (i <= domlo)
     {
-        if (bclo==BCType::ext_dir)
+        int bc = bc_arr ? bc_arr(domlo-1, j, k, n) : bclo;
+
+        if (bc==BCType::ext_dir)
         {
             lo = s(domlo-1,j,k,n);
             // For turbulent inflow, there are times when the inflow face
@@ -46,10 +49,10 @@ void SetXBCs (const int i, const int j, const int k, const int n,
             // tangential components to transport values from the interior.
             if( n == XVEL && is_velocity ) hi=lo;
         }
-        else if (bclo == BCType::foextrap || bclo == BCType::hoextrap)
+        else if (bc == BCType::foextrap || bc == BCType::hoextrap)
         {
             lo = hi;
-        } else if (bclo == BCType::reflect_even)
+        } else if (bc == BCType::reflect_even)
         {
             lo = hi;
 
@@ -63,10 +66,12 @@ void SetXBCs (const int i, const int j, const int k, const int n,
             // upwinded intermediate edge state in Imx (which supplies hi)
             // With GPU, I think it's undertermined which Imx(i+..) you'll get here,
             // could be from PLM, could be the upwinded edgestate.
+            // Question is whether every thread in the stream has to finish a kernel
+            // before the next kernel is launched.
             // lo = hi_arr(2*domlo-i  ,j,k,n);
             // hi = lo_arr(2*domlo-i-1,j,k,n);
         }
-        else if (bclo == BCType::reflect_odd)
+        else if (bc == BCType::reflect_odd)
         {
             if ( i==domlo ) {
                 hi = 0.;
@@ -81,16 +86,18 @@ void SetXBCs (const int i, const int j, const int k, const int n,
     // High X
     else if (i > domhi)
     {
-        if (bchi==BCType::ext_dir)
+        int bc = bc_arr ? bc_arr(domhi+1, j, k, n) : bchi;
+
+        if (bc==BCType::ext_dir)
         {
             hi = s(domhi+1,j,k,n) ;
             if( n ==XVEL && is_velocity ) lo=hi;
         }
-        else if (bchi == BCType::foextrap || bchi == BCType::hoextrap )
+        else if (bc == BCType::foextrap || bc == BCType::hoextrap )
         {
             hi = lo;
         }
-        else if (bchi == BCType::reflect_even)
+        else if (bc == BCType::reflect_even)
         {
             hi = lo;
 
@@ -99,7 +106,7 @@ void SetXBCs (const int i, const int j, const int k, const int n,
             // hi = lo_arr(2*(domhi+1)-i-1,j,k,n);
             // lo = hi_arr(2*(domhi+1)-i  ,j,k,n);
         }
-        else if (bchi == BCType::reflect_odd)
+        else if (bc == BCType::reflect_odd)
         {
             if ( i==domhi+1 ) {
                 hi = 0.;
@@ -122,7 +129,8 @@ void SetYBCs (const int i, const int j, const int k, const int n,
               amrex::Real &hi,
               const int bclo, const int bchi,
               const int domlo, const int domhi,
-              const bool is_velocity )
+              const bool is_velocity,
+              const amrex::Array4<const int> const& bc_arr = {})
 {
     using namespace amrex;
 
@@ -130,16 +138,18 @@ void SetYBCs (const int i, const int j, const int k, const int n,
     // Low Y
     if (j <= domlo)
     {
-        if (bclo==BCType::ext_dir)
+        int bc = bc_arr ? bc_arr(i, domlo-1, k, n) : bclo;
+
+        if (bc==BCType::ext_dir)
         {
             lo = s(i,domlo-1,k,n);
             if ( n == YVEL && is_velocity ) hi = lo;
         }
-        else if (bclo == BCType::foextrap || bclo == BCType::hoextrap)
+        else if (bc == BCType::foextrap || bc == BCType::hoextrap)
         {
             lo = hi;
         }
-        else if (bclo == BCType::reflect_even)
+        else if (bc == BCType::reflect_even)
         {
             lo = hi;
 
@@ -148,7 +158,7 @@ void SetYBCs (const int i, const int j, const int k, const int n,
             // lo = hi_arr(i,2*domlo-j  ,k,n);
             // hi = lo_arr(i,2*domlo-j-1,k,n);
         }
-        else if(bclo == BCType::reflect_odd)
+        else if(bc == BCType::reflect_odd)
         {
             if ( j==domlo ) {
                 hi = 0.;
@@ -163,16 +173,18 @@ void SetYBCs (const int i, const int j, const int k, const int n,
     // High Y
     else if (j > domhi)
     {
-        if (bchi==BCType::ext_dir)
+        int bc = bc_arr ? bc_arr(i, domhi+1, k, n) : bchi;
+
+        if (bc==BCType::ext_dir)
         {
             hi = s(i,domhi+1,k,n);
             if( n == YVEL && is_velocity ) lo = hi ;
         }
-        else if (bchi == BCType::foextrap || bchi == BCType::hoextrap)
+        else if (bc == BCType::foextrap || bc == BCType::hoextrap)
         {
             hi = lo;
         }
-        else if (bchi == BCType::reflect_even)
+        else if (bc == BCType::reflect_even)
         {
             hi = lo;
 
@@ -181,7 +193,7 @@ void SetYBCs (const int i, const int j, const int k, const int n,
             // hi = lo_arr(i,2*(domhi+1)-j-1,k,n);
             // lo = hi_arr(i,2*(domhi+1)-j  ,k,n);
         }
-        else if (bchi == BCType::reflect_odd)
+        else if (bc == BCType::reflect_odd)
         {
             if ( j==domhi+1 ) {
                 hi = 0.;
@@ -205,7 +217,8 @@ void SetZBCs(const int i, const int j, const int k, const int n,
              amrex::Real &hi,
              const int bclo, const int bchi,
              const int domlo, const int domhi,
-             const bool is_velocity)
+             const bool is_velocity,
+              const amrex::Array4<const int> const& bc_arr = {})
 {
     using namespace amrex;
 
@@ -213,22 +226,24 @@ void SetZBCs(const int i, const int j, const int k, const int n,
     // Low Z
     if (k <= domlo)
     {
-        if (bclo==BCType::ext_dir)
+        int bc = bc_arr ? bc_arr(i, j, domlo-1, n) : bclo;
+
+        if (bc==BCType::ext_dir)
         {
             lo =s(i,j,domlo-1,n);
             if ( n == ZVEL && is_velocity ) hi = lo;
         }
-        else if (bclo == BCType::foextrap || bclo == BCType::hoextrap)
+        else if (bc == BCType::foextrap || bc == BCType::hoextrap)
         {
             lo = hi;
         }
-        else if (bclo == BCType::reflect_even)
+        else if (bc == BCType::reflect_even)
         {
             Abort("EBGodunovBC::SetZBCs not yet implemented for reflect_even BC. See comments in EBGodunovBC::SetXBCs.");
             // lo = hi_arr(i,j,2*domlo-k  ,n);
             // hi = lo_arr(i,j,2*domlo-k-1,n);
         }
-        else if(bclo == BCType::reflect_odd)
+        else if(bc == BCType::reflect_odd)
         {
             Abort("EBGodunovBC::SetZBCs not yet implemented for reflect_odd BC. See comments in EBGodunovBC::SetXBCs.");
             // if ( k==domlo ) {
@@ -243,22 +258,24 @@ void SetZBCs(const int i, const int j, const int k, const int n,
     // High Z
     else if (k > domhi)
     {
-        if (bchi==BCType::ext_dir)
+        int bc = bc_arr ? bc_arr(i, j, domhi+1, n) : bchi;
+
+        if (bc==BCType::ext_dir)
         {
             hi = s(i,j,domhi+1,n);
             if ( n == ZVEL && is_velocity ) lo = hi ;
         }
-        else if (bchi == BCType::foextrap || bchi == BCType::hoextrap)
+        else if (bc == BCType::foextrap || bc == BCType::hoextrap)
         {
             hi = lo;
         }
-        else if (bchi == BCType::reflect_even)
+        else if (bc == BCType::reflect_even)
         {
             Abort("EBGodunovBC::SetZBCs not yet implemented for reflect_even BC. See comments in EBGodunovBC::SetXBCs.");
             // hi = lo_arr(i,j,2*(domhi+1)-k-1,n);
             // lo = hi_arr(i,j,2*(domhi+1)-k  ,n);
         }
-        else if (bchi == BCType::reflect_odd)
+        else if (bc == BCType::reflect_odd)
         {
             Abort("EBGodunovBC::SetZBCs not yet implemented for reflect_odd BC. See comments in EBGodunovBC::SetXBCs.");
             // if ( k==domhi+1 ) {

--- a/EBGodunov/hydro_ebgodunov_bcs_K.H
+++ b/EBGodunov/hydro_ebgodunov_bcs_K.H
@@ -30,7 +30,7 @@ void SetXBCs (const int i, const int j, const int k, const int n,
               const int bclo, const int bchi,
               const int domlo, const int domhi,
               const bool is_velocity,
-              const amrex::Array4<const int> const& bc_arr = {})
+              amrex::Array4<const int> const& bc_arr = {})
 {
     using namespace amrex;
 
@@ -130,7 +130,7 @@ void SetYBCs (const int i, const int j, const int k, const int n,
               const int bclo, const int bchi,
               const int domlo, const int domhi,
               const bool is_velocity,
-              const amrex::Array4<const int> const& bc_arr = {})
+              amrex::Array4<const int> const& bc_arr = {})
 {
     using namespace amrex;
 
@@ -218,7 +218,7 @@ void SetZBCs(const int i, const int j, const int k, const int n,
              const int bclo, const int bchi,
              const int domlo, const int domhi,
              const bool is_velocity,
-              const amrex::Array4<const int> const& bc_arr = {})
+             amrex::Array4<const int> const& bc_arr = {})
 {
     using namespace amrex;
 

--- a/EBGodunov/hydro_ebgodunov_bcs_K.H
+++ b/EBGodunov/hydro_ebgodunov_bcs_K.H
@@ -29,8 +29,7 @@ void SetXBCs (const int i, const int j, const int k, const int n,
               amrex::Real &hi,
               const int bclo, const int bchi,
               const int domlo, const int domhi,
-              const bool is_velocity,
-              amrex::Array4<const int> const& bc_arr = {})
+              const bool is_velocity )
 {
     using namespace amrex;
 
@@ -38,9 +37,7 @@ void SetXBCs (const int i, const int j, const int k, const int n,
     // Low X
     if (i <= domlo)
     {
-        int bc = bc_arr ? bc_arr(domlo-1, j, k, n) : bclo;
-
-        if (bc==BCType::ext_dir)
+        if (bclo==BCType::ext_dir)
         {
             lo = s(domlo-1,j,k,n);
             // For turbulent inflow, there are times when the inflow face
@@ -49,10 +46,10 @@ void SetXBCs (const int i, const int j, const int k, const int n,
             // tangential components to transport values from the interior.
             if( n == XVEL && is_velocity ) hi=lo;
         }
-        else if (bc == BCType::foextrap || bc == BCType::hoextrap)
+        else if (bclo == BCType::foextrap || bclo == BCType::hoextrap)
         {
             lo = hi;
-        } else if (bc == BCType::reflect_even)
+        } else if (bclo == BCType::reflect_even)
         {
             lo = hi;
 
@@ -71,7 +68,7 @@ void SetXBCs (const int i, const int j, const int k, const int n,
             // lo = hi_arr(2*domlo-i  ,j,k,n);
             // hi = lo_arr(2*domlo-i-1,j,k,n);
         }
-        else if (bc == BCType::reflect_odd)
+        else if (bclo == BCType::reflect_odd)
         {
             if ( i==domlo ) {
                 hi = 0.;
@@ -86,18 +83,16 @@ void SetXBCs (const int i, const int j, const int k, const int n,
     // High X
     else if (i > domhi)
     {
-        int bc = bc_arr ? bc_arr(domhi+1, j, k, n) : bchi;
-
-        if (bc==BCType::ext_dir)
+        if (bchi==BCType::ext_dir)
         {
             hi = s(domhi+1,j,k,n) ;
             if( n ==XVEL && is_velocity ) lo=hi;
         }
-        else if (bc == BCType::foextrap || bc == BCType::hoextrap )
+        else if (bchi == BCType::foextrap || bchi == BCType::hoextrap )
         {
             hi = lo;
         }
-        else if (bc == BCType::reflect_even)
+        else if (bchi == BCType::reflect_even)
         {
             hi = lo;
 
@@ -106,7 +101,7 @@ void SetXBCs (const int i, const int j, const int k, const int n,
             // hi = lo_arr(2*(domhi+1)-i-1,j,k,n);
             // lo = hi_arr(2*(domhi+1)-i  ,j,k,n);
         }
-        else if (bc == BCType::reflect_odd)
+        else if (bchi == BCType::reflect_odd)
         {
             if ( i==domhi+1 ) {
                 hi = 0.;
@@ -129,8 +124,7 @@ void SetYBCs (const int i, const int j, const int k, const int n,
               amrex::Real &hi,
               const int bclo, const int bchi,
               const int domlo, const int domhi,
-              const bool is_velocity,
-              amrex::Array4<const int> const& bc_arr = {})
+              const bool is_velocity )
 {
     using namespace amrex;
 
@@ -138,18 +132,16 @@ void SetYBCs (const int i, const int j, const int k, const int n,
     // Low Y
     if (j <= domlo)
     {
-        int bc = bc_arr ? bc_arr(i, domlo-1, k, n) : bclo;
-
-        if (bc==BCType::ext_dir)
+        if (bclo==BCType::ext_dir)
         {
             lo = s(i,domlo-1,k,n);
             if ( n == YVEL && is_velocity ) hi = lo;
         }
-        else if (bc == BCType::foextrap || bc == BCType::hoextrap)
+        else if (bclo == BCType::foextrap || bclo == BCType::hoextrap)
         {
             lo = hi;
         }
-        else if (bc == BCType::reflect_even)
+        else if (bclo == BCType::reflect_even)
         {
             lo = hi;
 
@@ -158,7 +150,7 @@ void SetYBCs (const int i, const int j, const int k, const int n,
             // lo = hi_arr(i,2*domlo-j  ,k,n);
             // hi = lo_arr(i,2*domlo-j-1,k,n);
         }
-        else if(bc == BCType::reflect_odd)
+        else if(bclo == BCType::reflect_odd)
         {
             if ( j==domlo ) {
                 hi = 0.;
@@ -173,18 +165,16 @@ void SetYBCs (const int i, const int j, const int k, const int n,
     // High Y
     else if (j > domhi)
     {
-        int bc = bc_arr ? bc_arr(i, domhi+1, k, n) : bchi;
-
-        if (bc==BCType::ext_dir)
+        if (bchi==BCType::ext_dir)
         {
             hi = s(i,domhi+1,k,n);
             if( n == YVEL && is_velocity ) lo = hi ;
         }
-        else if (bc == BCType::foextrap || bc == BCType::hoextrap)
+        else if (bchi == BCType::foextrap || bchi == BCType::hoextrap)
         {
             hi = lo;
         }
-        else if (bc == BCType::reflect_even)
+        else if (bchi == BCType::reflect_even)
         {
             hi = lo;
 
@@ -193,7 +183,7 @@ void SetYBCs (const int i, const int j, const int k, const int n,
             // hi = lo_arr(i,2*(domhi+1)-j-1,k,n);
             // lo = hi_arr(i,2*(domhi+1)-j  ,k,n);
         }
-        else if (bc == BCType::reflect_odd)
+        else if (bchi == BCType::reflect_odd)
         {
             if ( j==domhi+1 ) {
                 hi = 0.;
@@ -217,8 +207,7 @@ void SetZBCs(const int i, const int j, const int k, const int n,
              amrex::Real &hi,
              const int bclo, const int bchi,
              const int domlo, const int domhi,
-             const bool is_velocity,
-             amrex::Array4<const int> const& bc_arr = {})
+             const bool is_velocity)
 {
     using namespace amrex;
 
@@ -226,24 +215,22 @@ void SetZBCs(const int i, const int j, const int k, const int n,
     // Low Z
     if (k <= domlo)
     {
-        int bc = bc_arr ? bc_arr(i, j, domlo-1, n) : bclo;
-
-        if (bc==BCType::ext_dir)
+        if (bclo==BCType::ext_dir)
         {
             lo =s(i,j,domlo-1,n);
             if ( n == ZVEL && is_velocity ) hi = lo;
         }
-        else if (bc == BCType::foextrap || bc == BCType::hoextrap)
+        else if (bclo == BCType::foextrap || bclo == BCType::hoextrap)
         {
             lo = hi;
         }
-        else if (bc == BCType::reflect_even)
+        else if (bclo == BCType::reflect_even)
         {
             Abort("EBGodunovBC::SetZBCs not yet implemented for reflect_even BC. See comments in EBGodunovBC::SetXBCs.");
             // lo = hi_arr(i,j,2*domlo-k  ,n);
             // hi = lo_arr(i,j,2*domlo-k-1,n);
         }
-        else if(bc == BCType::reflect_odd)
+        else if(bclo == BCType::reflect_odd)
         {
             Abort("EBGodunovBC::SetZBCs not yet implemented for reflect_odd BC. See comments in EBGodunovBC::SetXBCs.");
             // if ( k==domlo ) {
@@ -258,24 +245,22 @@ void SetZBCs(const int i, const int j, const int k, const int n,
     // High Z
     else if (k > domhi)
     {
-        int bc = bc_arr ? bc_arr(i, j, domhi+1, n) : bchi;
-
-        if (bc==BCType::ext_dir)
+        if (bchi==BCType::ext_dir)
         {
             hi = s(i,j,domhi+1,n);
             if ( n == ZVEL && is_velocity ) lo = hi ;
         }
-        else if (bc == BCType::foextrap || bc == BCType::hoextrap)
+        else if (bchi == BCType::foextrap || bchi == BCType::hoextrap)
         {
             hi = lo;
         }
-        else if (bc == BCType::reflect_even)
+        else if (bchi == BCType::reflect_even)
         {
             Abort("EBGodunovBC::SetZBCs not yet implemented for reflect_even BC. See comments in EBGodunovBC::SetXBCs.");
             // hi = lo_arr(i,j,2*(domhi+1)-k-1,n);
             // lo = hi_arr(i,j,2*(domhi+1)-k  ,n);
         }
-        else if (bc == BCType::reflect_odd)
+        else if (bchi == BCType::reflect_odd)
         {
             Abort("EBGodunovBC::SetZBCs not yet implemented for reflect_odd BC. See comments in EBGodunovBC::SetXBCs.");
             // if ( k==domhi+1 ) {

--- a/EBGodunov/hydro_ebgodunov_edge_state_2D.cpp
+++ b/EBGodunov/hydro_ebgodunov_edge_state_2D.cpp
@@ -36,7 +36,8 @@ EBGodunov::ComputeEdgeState ( Box const& bx, int ncomp,
                               Array4<Real const> const& fcy,
                               Array4<Real const> const& ccent_arr,
                               bool is_velocity,
-                              Array4<Real const> const& values_on_eb_inflow)
+                              Array4<Real const> const& values_on_eb_inflow,
+                              Array4<int const> const& dirichlet_mask)
 {
     Box const& xbx = amrex::surroundingNodes(bx,0);
     Box const& ybx = amrex::surroundingNodes(bx,1);

--- a/EBGodunov/hydro_ebgodunov_edge_state_2D.cpp
+++ b/EBGodunov/hydro_ebgodunov_edge_state_2D.cpp
@@ -37,7 +37,7 @@ EBGodunov::ComputeEdgeState ( Box const& bx, int ncomp,
                               Array4<Real const> const& ccent_arr,
                               bool is_velocity,
                               Array4<Real const> const& values_on_eb_inflow,
-                              Array4<int const> const& dirichlet_mask)
+                              Array4<int const> const& bc_arr)
 {
     Box const& xbx = amrex::surroundingNodes(bx,0);
     Box const& ybx = amrex::surroundingNodes(bx,1);
@@ -107,7 +107,7 @@ EBGodunov::ComputeEdgeState ( Box const& bx, int ncomp,
             Real lo = Ipx(i-1,j,k,n);
             Real hi = Imx(i  ,j,k,n);
 
-            auto bc = pbc[n];
+            const auto bc = HydroBC::getBC(i, j, k, n, domain, pbc, bc_arr);
 
             HydroBC::SetXEdgeBCs(i, j, k, n, q, lo, hi, bc.lo(0), dlo.x, bc.hi(0), dhi.x, is_velocity);
 
@@ -119,7 +119,7 @@ EBGodunov::ComputeEdgeState ( Box const& bx, int ncomp,
             Real lo = Ipy(i,j-1,k,n);
             Real hi = Imy(i,j  ,k,n);
 
-            auto bc = pbc[n];
+            const auto bc = HydroBC::getBC(i, j, k, n, domain, pbc, bc_arr);
 
             HydroBC::SetYEdgeBCs(i, j, k, n, q, lo, hi, bc.lo(1), dlo.y, bc.hi(1), dhi.y, is_velocity);
 
@@ -137,7 +137,7 @@ EBGodunov::ComputeEdgeState ( Box const& bx, int ncomp,
     {
         if (apy(i,j,k) > 0.)
         {
-            const auto bc = pbc[n];
+            const auto bc = HydroBC::getBC(i, j, k, n, domain, pbc, bc_arr);
             Real l_yzlo, l_yzhi;
 
             l_yzlo = ylo(i,j,k,n);
@@ -219,7 +219,7 @@ EBGodunov::ComputeEdgeState ( Box const& bx, int ncomp,
                 sth += (fq)           ? 0.5*l_dt*fq(i  ,j,k,n) : 0.;
             }
 
-            auto bc = pbc[n];
+            const auto bc = HydroBC::getBC(i, j, k, n, domain, pbc, bc_arr);
             HydroBC::SetXEdgeBCs(i, j, k, n, q, stl, sth, bc.lo(0), dlo.x, bc.hi(0), dhi.x, is_velocity);
 
             if ( (i==dlo.x) && (bc.lo(0) == BCType::foextrap || bc.lo(0) == BCType::hoextrap) )
@@ -252,7 +252,7 @@ EBGodunov::ComputeEdgeState ( Box const& bx, int ncomp,
     {
         if (apx(i,j,k) > 0.)
         {
-            const auto bc = pbc[n];
+            const auto bc = HydroBC::getBC(i, j, k, n, domain, pbc, bc_arr);
             Real l_xzlo, l_xzhi;
 
             l_xzlo = xlo(i,j,k,n);
@@ -335,7 +335,7 @@ EBGodunov::ComputeEdgeState ( Box const& bx, int ncomp,
                 sth += (fq)           ? 0.5*l_dt*fq(i,j,k,n) : 0.;
             }
 
-            auto bc = pbc[n];
+            const auto bc = HydroBC::getBC(i, j, k, n, domain, pbc, bc_arr);
             HydroBC::SetYEdgeBCs(i, j, k, n, q, stl, sth, bc.lo(1), dlo.y, bc.hi(1), dhi.y, is_velocity);
 
             if ( (j==dlo.y) && (bc.lo(1) == BCType::foextrap || bc.lo(1) == BCType::hoextrap) )

--- a/EBGodunov/hydro_ebgodunov_edge_state_3D.cpp
+++ b/EBGodunov/hydro_ebgodunov_edge_state_3D.cpp
@@ -40,7 +40,7 @@ EBGodunov::ComputeEdgeState ( Box const& bx, int ncomp,
                               Array4<Real const> const& ccent_arr,
                               bool is_velocity,
                               Array4<Real const> const& values_on_eb_inflow,
-                              Array4<int const> const& dirichlet_mask)
+                              Array4<int const> const& bc_arr)
 {
 
     // bx is the cell-centered box on which we want to compute the advective update
@@ -136,7 +136,7 @@ EBGodunov::ComputeEdgeState ( Box const& bx, int ncomp,
 
             Real uad = u_mac(i,j,k);
 
-            auto bc = pbc[n];
+            const auto bc = HydroBC::getBC(i, j, k, n, domain, pbc, bc_arr);
 
             HydroBC::SetXEdgeBCs(i, j, k, n, q, lo, hi, bc.lo(0), dlo.x, bc.hi(0), dhi.x, is_velocity);
 
@@ -154,7 +154,7 @@ EBGodunov::ComputeEdgeState ( Box const& bx, int ncomp,
 
             Real vad = v_mac(i,j,k);
 
-            auto bc = pbc[n];
+            const auto bc = HydroBC::getBC(i, j, k, n, domain, pbc, bc_arr);
 
             HydroBC::SetYEdgeBCs(i, j, k, n, q, lo, hi, bc.lo(1), dlo.y, bc.hi(1), dhi.y, is_velocity);
 
@@ -172,7 +172,7 @@ EBGodunov::ComputeEdgeState ( Box const& bx, int ncomp,
 
             Real wad = w_mac(i,j,k);
 
-            auto bc = pbc[n];
+            const auto bc = HydroBC::getBC(i, j, k, n, domain, pbc, bc_arr);
 
             HydroBC::SetZEdgeBCs(i, j, k, n, q, lo, hi, bc.lo(2), dlo.z, bc.hi(2), dhi.z, is_velocity);
 
@@ -200,7 +200,7 @@ EBGodunov::ComputeEdgeState ( Box const& bx, int ncomp,
     Box(zylo), ncomp,
     [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
     {
-        const auto bc = pbc[n];
+        const auto bc = HydroBC::getBC(i, j, k, n, domain, pbc, bc_arr);
         Real l_zylo, l_zyhi;
         EBGodunovCornerCouple::EBGodunov_corner_couple_zy(l_zylo, l_zyhi,
                                    i, j, k, n, l_dt, dy, iconserv[n],
@@ -217,7 +217,7 @@ EBGodunov::ComputeEdgeState ( Box const& bx, int ncomp,
     Box(yzlo), ncomp,
     [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
     {
-        const auto bc = pbc[n];
+        const auto bc = HydroBC::getBC(i, j, k, n, domain, pbc, bc_arr);
         Real l_yzlo, l_yzhi;
         EBGodunovCornerCouple::EBGodunov_corner_couple_yz(l_yzlo, l_yzhi,
                                    i, j, k, n, l_dt, dz, iconserv[n],
@@ -303,7 +303,7 @@ EBGodunov::ComputeEdgeState ( Box const& bx, int ncomp,
                 sth += (fq)           ? Real(0.5)*l_dt*fq(i  ,j,k,n) : Real(0.0);
             }
 
-            auto bc = pbc[n];
+            const auto bc = HydroBC::getBC(i, j, k, n, domain, pbc, bc_arr);
             HydroBC::SetXEdgeBCs(i, j, k, n, q, stl, sth, bc.lo(0), dlo.x, bc.hi(0), dhi.x, is_velocity);
 
             if ( (i==dlo.x) && (bc.lo(0) == BCType::foextrap || bc.lo(0) == BCType::hoextrap) )
@@ -337,7 +337,7 @@ EBGodunov::ComputeEdgeState ( Box const& bx, int ncomp,
     Box(xzlo), ncomp,
     [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
     {
-        const auto bc = pbc[n];
+        const auto bc = HydroBC::getBC(i, j, k, n, domain, pbc, bc_arr);
         Real l_xzlo, l_xzhi;
         EBGodunovCornerCouple::EBGodunov_corner_couple_xz(l_xzlo, l_xzhi,
                                    i, j, k, n, l_dt, dz, iconserv[n],
@@ -354,7 +354,7 @@ EBGodunov::ComputeEdgeState ( Box const& bx, int ncomp,
     Box(zxlo), ncomp,
     [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
     {
-        const auto bc = pbc[n];
+        const auto bc = HydroBC::getBC(i, j, k, n, domain, pbc, bc_arr);
         Real l_zxlo, l_zxhi;
         EBGodunovCornerCouple::EBGodunov_corner_couple_zx(l_zxlo, l_zxhi,
                                    i, j, k, n, l_dt, dx, iconserv[n],
@@ -440,7 +440,7 @@ EBGodunov::ComputeEdgeState ( Box const& bx, int ncomp,
                 sth += (fq)           ? Real(0.5)*l_dt*fq(i,j,k,n) : Real(0.0);
             }
 
-            auto bc = pbc[n];
+            const auto bc = HydroBC::getBC(i, j, k, n, domain, pbc, bc_arr);
             HydroBC::SetYEdgeBCs(i, j, k, n, q, stl, sth, bc.lo(1), dlo.y, bc.hi(1), dhi.y, is_velocity);
 
             if ( (j==dlo.y) && (bc.lo(1) == BCType::foextrap || bc.lo(1) == BCType::hoextrap) )
@@ -472,7 +472,7 @@ EBGodunov::ComputeEdgeState ( Box const& bx, int ncomp,
     Box(xylo), ncomp,
     [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
     {
-        const auto bc = pbc[n];
+        const auto bc = HydroBC::getBC(i, j, k, n, domain, pbc, bc_arr);
         Real l_xylo, l_xyhi;
         EBGodunovCornerCouple::EBGodunov_corner_couple_xy(l_xylo, l_xyhi,
                                    i, j, k, n, l_dt, dy, iconserv[n],
@@ -489,7 +489,7 @@ EBGodunov::ComputeEdgeState ( Box const& bx, int ncomp,
     Box(yxlo), ncomp,
     [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
     {
-        const auto bc = pbc[n];
+        const auto bc = HydroBC::getBC(i, j, k, n, domain, pbc, bc_arr);
         Real l_yxlo, l_yxhi;
         EBGodunovCornerCouple::EBGodunov_corner_couple_yx(l_yxlo, l_yxhi,
                                    i, j, k, n, l_dt, dx, iconserv[n],
@@ -574,7 +574,7 @@ EBGodunov::ComputeEdgeState ( Box const& bx, int ncomp,
                 sth += (fq)           ? Real(0.5)*l_dt*fq(i,j,k,n) : Real(0.0);
             }
 
-            auto bc = pbc[n];
+            const auto bc = HydroBC::getBC(i, j, k, n, domain, pbc, bc_arr);
             HydroBC::SetZEdgeBCs(i, j, k, n, q, stl, sth, bc.lo(2), dlo.z, bc.hi(2), dhi.z, is_velocity);
 
             if ( (k==dlo.z) && (bc.lo(2) == BCType::foextrap || bc.lo(2) == BCType::hoextrap) )

--- a/EBGodunov/hydro_ebgodunov_edge_state_3D.cpp
+++ b/EBGodunov/hydro_ebgodunov_edge_state_3D.cpp
@@ -39,7 +39,8 @@ EBGodunov::ComputeEdgeState ( Box const& bx, int ncomp,
                               Array4<Real const> const& fcz,
                               Array4<Real const> const& ccent_arr,
                               bool is_velocity,
-                              Array4<Real const> const& values_on_eb_inflow)
+                              Array4<Real const> const& values_on_eb_inflow,
+                              Array4<int const> const& dirichlet_mask)
 {
 
     // bx is the cell-centered box on which we want to compute the advective update

--- a/EBGodunov/hydro_ebgodunov_extrap_vel_to_faces.cpp
+++ b/EBGodunov/hydro_ebgodunov_extrap_vel_to_faces.cpp
@@ -274,9 +274,8 @@ EBGodunov::ComputeAdvectiveVel ( AMREX_D_DECL(Box const& xbx,
             Real lo = Ipx(i-1,j,k,n);
             Real hi = Imx(i  ,j,k,n);
 
-            auto bc = pbc[n];
-            EBGodunovBC::SetXBCs(i, j, k, n, vel, lo, hi, bc.lo(0), bc.hi(0), dlo.x, dhi.x,
-                                 true, bc_arr);
+            const auto bc = HydroBC::getBC(i, j, k, n, domain, pbc, bc_arr);
+            EBGodunovBC::SetXBCs(i, j, k, n, vel, lo, hi, bc.lo(0), bc.hi(0), dlo.x, dhi.x, true);
 
             Real st = ( (lo+hi) >= 0.) ? lo : hi;
             bool ltm = ( (lo <= 0. && hi >= 0.) || (amrex::Math::abs(lo+hi) < small_vel) );
@@ -295,9 +294,8 @@ EBGodunov::ComputeAdvectiveVel ( AMREX_D_DECL(Box const& xbx,
             Real lo = Ipy(i,j-1,k,n);
             Real hi = Imy(i,j  ,k,n);
 
-            auto bc = pbc[n];
-            EBGodunovBC::SetYBCs(i, j, k, n, vel, lo, hi, bc.lo(1), bc.hi(1), dlo.y, dhi.y,
-                                 true, bc_arr);
+            const auto bc = HydroBC::getBC(i, j, k, n, domain, pbc, bc_arr);
+            EBGodunovBC::SetYBCs(i, j, k, n, vel, lo, hi, bc.lo(1), bc.hi(1), dlo.y, dhi.y, true);
 
             Real st = ( (lo+hi) >= 0.) ? lo : hi;
             bool ltm = ( (lo <= 0. && hi >= 0.) || (amrex::Math::abs(lo+hi) < small_vel) );
@@ -317,9 +315,8 @@ EBGodunov::ComputeAdvectiveVel ( AMREX_D_DECL(Box const& xbx,
             Real lo = Ipz(i,j,k-1,n);
             Real hi = Imz(i,j,k  ,n);
 
-            auto bc = pbc[n];
-            EBGodunovBC::SetZBCs(i, j, k, n, vel, lo, hi, bc.lo(2), bc.hi(2), dlo.z, dhi.z,
-                                 true, bcc_arr);
+            const auto bc = HydroBC::getBC(i, j, k, n, domain, pbc, bc_arr);
+            EBGodunovBC::SetZBCs(i, j, k, n, vel, lo, hi, bc.lo(2), bc.hi(2), dlo.z, dhi.z, true);
 
             Real st = ( (lo+hi) >= 0.) ? lo : hi;
             bool ltm = ( (lo <= 0. && hi >= 0.) || (amrex::Math::abs(lo+hi) < small_vel) );

--- a/EBGodunov/hydro_ebgodunov_extrap_vel_to_faces.cpp
+++ b/EBGodunov/hydro_ebgodunov_extrap_vel_to_faces.cpp
@@ -65,7 +65,7 @@ EBGodunov::ExtrapVelToFaces ( MultiFab const& vel,
             Array4<Real const> const& a_vel = vel.const_array(mfi);
             Array4<Real const> const& a_f = vel_forces.const_array(mfi);
 
-            Array4<int const> const& bc_arr = BC_MF ? BC_MF.const_array(mfi)
+            Array4<int const> const& bc_arr = BC_MF ? BC_MF->const_array(mfi)
                                                     : Array4<int const> {};
 
             // In 2-d:

--- a/EBGodunov/hydro_ebgodunov_extrap_vel_to_faces_2D.cpp
+++ b/EBGodunov/hydro_ebgodunov_extrap_vel_to_faces_2D.cpp
@@ -61,10 +61,9 @@ EBGodunov::ExtrapVelToFacesOnBox (Box const& /*bx*/, int ncomp,
             Real lo = Ipx(i-1,j,k,n);
             Real hi = Imx(i  ,j,k,n);
 
-            auto bc = pbc[n];
+            const auto bc = HydroBC::getBC(i, j, k, n, domain, pbc, bc_arr);
 
-            HydroBC::SetXEdgeBCs(i, j, k, n, q, lo, hi, bc.lo(0), dlo.x, bc.hi(0), dhi.x,
-                                 true, bc_arr);
+            HydroBC::SetXEdgeBCs(i, j, k, n, q, lo, hi, bc.lo(0), dlo.x, bc.hi(0), dhi.x, true);
 
             xlo(i,j,k,n) = lo;
             xhi(i,j,k,n) = hi;
@@ -74,10 +73,9 @@ EBGodunov::ExtrapVelToFacesOnBox (Box const& /*bx*/, int ncomp,
             Real lo = Ipy(i,j-1,k,n);
             Real hi = Imy(i,j  ,k,n);
 
-            auto bc = pbc[n];
+            const auto bc = HydroBC::getBC(i, j, k, n, domain, pbc, bc_arr);
 
-            HydroBC::SetYEdgeBCs(i, j, k, n, q, lo, hi, bc.lo(1), dlo.y, bc.hi(1), dhi.y,
-                                 true, bc_arr);
+            HydroBC::SetYEdgeBCs(i, j, k, n, q, lo, hi, bc.lo(1), dlo.y, bc.hi(1), dhi.y, true);
 
             ylo(i,j,k,n) = lo;
             yhi(i,j,k,n) = hi;
@@ -99,14 +97,13 @@ EBGodunov::ExtrapVelToFacesOnBox (Box const& /*bx*/, int ncomp,
         if (flag(i,j,k).isConnected(0,-1,0))
         {
             constexpr int n = 0;
-            const auto bc = pbc[n];
+            const auto bc = HydroBC::getBC(i, j, k, n, domain, pbc, bc_arr);
             Real l_yzlo, l_yzhi;
 
             l_yzlo = ylo(i,j,k,n);
             l_yzhi = yhi(i,j,k,n);
             Real vad = v_ad(i,j,k);
-            HydroBC::SetYEdgeBCs(i, j, k, n, q, l_yzlo, l_yzhi, bc.lo(1), dlo.y, bc.hi(1), dhi.y,
-                                 true, bc_arr);
+            HydroBC::SetYEdgeBCs(i, j, k, n, q, l_yzlo, l_yzhi, bc.lo(1), dlo.y, bc.hi(1), dhi.y, true);
 
             Real st = (vad >= 0.) ? l_yzlo : l_yzhi;
             Real fu = (amrex::Math::abs(vad) < small_vel) ? 0.0 : 1.0;
@@ -125,7 +122,7 @@ EBGodunov::ExtrapVelToFacesOnBox (Box const& /*bx*/, int ncomp,
         if (flag(i,j,k).isConnected(-1,0,0))
         {
         constexpr int n = 0;
-        auto bc = pbc[n];
+        const auto bc = HydroBC::getBC(i, j, k, n, domain, pbc, bc_arr);
 
         // stl is on the left  side of the lo-x side of cell (i,j)
         // sth is on the right side of the lo-x side of cell (i,j)
@@ -191,18 +188,15 @@ EBGodunov::ExtrapVelToFacesOnBox (Box const& /*bx*/, int ncomp,
             }
         }
 
-        HydroBC::SetXEdgeBCs(i, j, k, n, q, stl, sth, bc.lo(0), dlo.x, bc.hi(0), dhi.x,
-                             true, bc_arr);
+        HydroBC::SetXEdgeBCs(i, j, k, n, q, stl, sth, bc.lo(0), dlo.x, bc.hi(0), dhi.x, true);
 
         // Prevent backflow
-        int bclo = (i==dlo.x && bc_arr) ? bc_arr(dlo.x-1, j, k, n) : bc.lo(0);
-        if ( (i==dlo.x) && (bclo == BCType::foextrap || bclo == BCType::hoextrap) )
+        if ( (i==dlo.x) && (bc.lo(0) == BCType::foextrap || bc.lo(0) == BCType::hoextrap) )
         {
             sth = amrex::min(sth,0.0_rt);
             stl = sth;
         }
-        int bchi = (i==dhi.x+1 && bc_arr) ? bc_arr(dhi.x+1, j, k, n) : bc.hi(0);
-        if ( (i==dhi.x+1) && (bchi == BCType::foextrap || bchi == BCType::hoextrap) )
+        if ( (i==dhi.x+1) && (bc.hi(0) == BCType::foextrap || bc.hi(0) == BCType::hoextrap) )
         {
              stl = amrex::max(stl,0.0_rt);
              sth = stl;
@@ -228,15 +222,14 @@ EBGodunov::ExtrapVelToFacesOnBox (Box const& /*bx*/, int ncomp,
         if (flag(i,j,k).isConnected(-1,0,0))
         {
             constexpr int n = 1;
-            const auto bc = pbc[n];
+            const auto bc = HydroBC::getBC(i, j, k, n, domain, pbc, bc_arr);
             Real l_xzlo, l_xzhi;
 
             l_xzlo = xlo(i,j,k,n);
             l_xzhi = xhi(i,j,k,n);
 
             Real uad = u_ad(i,j,k);
-            HydroBC::SetXEdgeBCs(i, j, k, n, q, l_xzlo, l_xzhi, bc.lo(0), dlo.x, bc.hi(0), dhi.x,
-                                 true, bc_arr);
+            HydroBC::SetXEdgeBCs(i, j, k, n, q, l_xzlo, l_xzhi, bc.lo(0), dlo.x, bc.hi(0), dhi.x, true);
 
             Real st = (uad >= 0.) ? l_xzlo : l_xzhi;
             Real fu = (amrex::Math::abs(uad) < small_vel) ? 0.0 : 1.0;
@@ -254,7 +247,7 @@ EBGodunov::ExtrapVelToFacesOnBox (Box const& /*bx*/, int ncomp,
         if (flag(i,j,k).isConnected(0,-1,0))
         {
         constexpr int n = 1;
-        auto bc = pbc[n];
+        const auto bc = HydroBC::getBC(i, j, k, n, domain, pbc, bc_arr);
 
         // stl is on the low  side of the lo-y side of cell (i,j)
         // sth is on the high side of the lo-y side of cell (i,j)
@@ -317,18 +310,15 @@ EBGodunov::ExtrapVelToFacesOnBox (Box const& /*bx*/, int ncomp,
             }
         }
 
-        HydroBC::SetYEdgeBCs(i, j, k, n, q, stl, sth, bc.lo(1), dlo.y, bc.hi(1), dhi.y,
-                             true, bc_arr);
+        HydroBC::SetYEdgeBCs(i, j, k, n, q, stl, sth, bc.lo(1), dlo.y, bc.hi(1), dhi.y, true);
 
         // Prevent backflow
-        int bclo = (j==dlo.y && bc_arr) ? bc_arr(i, dlo.y-1, k, n) : bc.lo(1);
-        if ( (j==dlo.y) && (bclo == BCType::foextrap || bclo == BCType::hoextrap) )
+        if ( (j==dlo.y) && (bc.lo(1) == BCType::foextrap || bc.lo(1) == BCType::hoextrap) )
         {
             sth = amrex::min(sth,0.0_rt);
             stl = sth;
-        } 
-        int bchi = (j==dhi.y+1 && bc_arr) ? bc_arr(i, dhi.y+1, k, n) : bc.hi(1);
-        if ( (j==dhi.y+1) && (bchi == BCType::foextrap || bchi == BCType::hoextrap) )
+        }
+        if ( (j==dhi.y+1) && (bc.hi(1) == BCType::foextrap || bc.hi(1) == BCType::hoextrap) )
         {
             stl = amrex::max(stl,0.0_rt);
             sth = stl;

--- a/EBGodunov/hydro_ebgodunov_extrap_vel_to_faces_2D.cpp
+++ b/EBGodunov/hydro_ebgodunov_extrap_vel_to_faces_2D.cpp
@@ -195,14 +195,14 @@ EBGodunov::ExtrapVelToFacesOnBox (Box const& /*bx*/, int ncomp,
                              true, bc_arr);
 
         // Prevent backflow
-        int bc = (i==dlo.x && bc_arr) ? bc_arr(dlo.x-1, j, k, n) : bc.lo(0);
-        if ( (i==dlo.x) && (bc == BCType::foextrap || bc == BCType::hoextrap) )
+        int bclo = (i==dlo.x && bc_arr) ? bc_arr(dlo.x-1, j, k, n) : bc.lo(0);
+        if ( (i==dlo.x) && (bclo == BCType::foextrap || bclo == BCType::hoextrap) )
         {
             sth = amrex::min(sth,0.0_rt);
             stl = sth;
         }
-        bc = (i==dhi.x+1 && bc_arr) ? bc_arr(dhi.x+1, j, k, n) : bc.hi(0);
-        if ( (i==dhi.x+1) && (bc == BCType::foextrap || bc == BCType::hoextrap) )
+        int bchi = (i==dhi.x+1 && bc_arr) ? bc_arr(dhi.x+1, j, k, n) : bc.hi(0);
+        if ( (i==dhi.x+1) && (bchi == BCType::foextrap || bchi == BCType::hoextrap) )
         {
              stl = amrex::max(stl,0.0_rt);
              sth = stl;
@@ -321,14 +321,14 @@ EBGodunov::ExtrapVelToFacesOnBox (Box const& /*bx*/, int ncomp,
                              true, bc_arr);
 
         // Prevent backflow
-        int bc = (j==dlo.y && bc_arr) ? bc_arr(i, dlo.y-1, k, n) : bc.lo(1);
-        if ( (j==dlo.y) && (bc == BCType::foextrap || bc == BCType::hoextrap) )
+        int bclo = (j==dlo.y && bc_arr) ? bc_arr(i, dlo.y-1, k, n) : bc.lo(1);
+        if ( (j==dlo.y) && (bclo == BCType::foextrap || bclo == BCType::hoextrap) )
         {
             sth = amrex::min(sth,0.0_rt);
             stl = sth;
         } 
-        bc = (j==dhi.y+1 && bc_arr) ? bc_arr(i, dhi.y+1, k, n) : bc.hi(1);
-        if ( (j==dhi.y+1) && (bc == BCType::foextrap || bc == BCType::hoextrap) )
+        int bchi = (j==dhi.y+1 && bc_arr) ? bc_arr(i, dhi.y+1, k, n) : bc.hi(1);
+        if ( (j==dhi.y+1) && (bchi == BCType::foextrap || bchi == BCType::hoextrap) )
         {
             stl = amrex::max(stl,0.0_rt);
             sth = stl;

--- a/EBGodunov/hydro_ebgodunov_extrap_vel_to_faces_3D.cpp
+++ b/EBGodunov/hydro_ebgodunov_extrap_vel_to_faces_3D.cpp
@@ -48,7 +48,7 @@ EBGodunov::ExtrapVelToFacesOnBox ( Box const& bx, int ncomp,
                                    Array4<Real const> const& fcz,
                                    Real* p,
                                    Array4<Real const> const& velocity_on_eb_inflow,
-                                   Array4<int const> const& dirichlet_mask)
+                                   Array4<int const> const& bc_arr)
 {
     const Dim3 dlo = amrex::lbound(domain);
     const Dim3 dhi = amrex::ubound(domain);
@@ -75,7 +75,7 @@ EBGodunov::ExtrapVelToFacesOnBox ( Box const& bx, int ncomp,
             Real hi = Imx(i  ,j,k,n);
 
             Real uad = u_ad(i,j,k);
-            auto bc = pbc[n];
+            const auto bc = HydroBC::getBC(i, j, k, n, domain, pbc, bc_arr);
 
             EBGodunovBC::SetXBCs(i, j, k, n, q, lo, hi, bc.lo(0), bc.hi(0), dlo.x, dhi.x, true);
 
@@ -92,7 +92,7 @@ EBGodunov::ExtrapVelToFacesOnBox ( Box const& bx, int ncomp,
             Real hi = Imy(i,j  ,k,n);
 
             Real vad = v_ad(i,j,k);
-            auto bc = pbc[n];
+            const auto bc = HydroBC::getBC(i, j, k, n, domain, pbc, bc_arr);
 
             EBGodunovBC::SetYBCs(i, j, k, n, q, lo, hi, bc.lo(1), bc.hi(1), dlo.y, dhi.y, true);
 
@@ -109,7 +109,7 @@ EBGodunov::ExtrapVelToFacesOnBox ( Box const& bx, int ncomp,
             Real hi = Imz(i,j,k  ,n);
 
             Real wad = w_ad(i,j,k);
-            auto bc = pbc[n];
+            const auto bc = HydroBC::getBC(i, j, k, n, domain, pbc, bc_arr);
 
             EBGodunovBC::SetZBCs(i, j, k, n, q, lo, hi, bc.lo(2), bc.hi(2), dlo.z, dhi.z, true);
 
@@ -156,7 +156,7 @@ EBGodunov::ExtrapVelToFacesOnBox ( Box const& bx, int ncomp,
     [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
     {
         constexpr int n = 0;
-        auto bc = pbc[n];
+        const auto bc = HydroBC::getBC(i, j, k, n, domain, pbc, bc_arr);
         Real l_zylo, l_zyhi;
         EBGodunovCornerCouple::EBGodunov_corner_couple_zy(l_zylo, l_zyhi,
                                    i, j, k, n, l_dt, dy, false,
@@ -174,7 +174,7 @@ EBGodunov::ExtrapVelToFacesOnBox ( Box const& bx, int ncomp,
     [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
     {
         constexpr int n = 0;
-        auto bc = pbc[n];
+        const auto bc = HydroBC::getBC(i, j, k, n, domain, pbc, bc_arr);
         Real l_yzlo, l_yzhi;
         EBGodunovCornerCouple::EBGodunov_corner_couple_yz(l_yzlo, l_yzhi,
                                    i, j, k, n, l_dt, dz, false,
@@ -194,7 +194,7 @@ EBGodunov::ExtrapVelToFacesOnBox ( Box const& bx, int ncomp,
         if (flag(i,j,k).isConnected(-1,0,0))
         {
         constexpr int n = 0;
-        auto bc = pbc[n];
+        const auto bc = HydroBC::getBC(i, j, k, n, domain, pbc, bc_arr);
 
         // stl is on the lo side of the lo-x side of cell (i,j,k)
         // sth is on the hi side of the lo-x side of cell (i,j,k)
@@ -307,7 +307,7 @@ EBGodunov::ExtrapVelToFacesOnBox ( Box const& bx, int ncomp,
     [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
     {
         constexpr int n = 1;
-        const auto bc = pbc[n];
+        const const auto bc = HydroBC::getBC(i, j, k, n, domain, pbc, bc_arr);
         Real l_xzlo, l_xzhi;
         EBGodunovCornerCouple::EBGodunov_corner_couple_xz(l_xzlo, l_xzhi,
                                    i, j, k, n, l_dt, dz, false,
@@ -325,7 +325,7 @@ EBGodunov::ExtrapVelToFacesOnBox ( Box const& bx, int ncomp,
     [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
     {
         constexpr int n = 1;
-        const auto bc = pbc[n];
+        const const auto bc = HydroBC::getBC(i, j, k, n, domain, pbc, bc_arr);
         Real l_zxlo, l_zxhi;
         EBGodunovCornerCouple::EBGodunov_corner_couple_zx(l_zxlo, l_zxhi,
                                    i, j, k, n, l_dt, dx, false,
@@ -346,7 +346,7 @@ EBGodunov::ExtrapVelToFacesOnBox ( Box const& bx, int ncomp,
         if (flag(i,j,k).isConnected(0,-1,0))
         {
         constexpr int n = 1;
-        auto bc = pbc[n];
+        const auto bc = HydroBC::getBC(i, j, k, n, domain, pbc, bc_arr);
 
         // stl is on the lo side of the lo-y side of cell (i,j,k)
         // sth is on the hi side of the lo-y side of cell (i,j,k)
@@ -459,7 +459,7 @@ EBGodunov::ExtrapVelToFacesOnBox ( Box const& bx, int ncomp,
     [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
     {
         constexpr int n = 2;
-        const auto bc = pbc[n];
+        const const auto bc = HydroBC::getBC(i, j, k, n, domain, pbc, bc_arr);
         Real l_xylo, l_xyhi;
         EBGodunovCornerCouple::EBGodunov_corner_couple_xy(l_xylo, l_xyhi,
                                    i, j, k, n, l_dt, dy, false,
@@ -481,7 +481,7 @@ EBGodunov::ExtrapVelToFacesOnBox ( Box const& bx, int ncomp,
     [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
     {
         constexpr int n = 2;
-        const auto bc = pbc[n];
+        const const auto bc = HydroBC::getBC(i, j, k, n, domain, pbc, bc_arr);
         Real l_yxlo, l_yxhi;
         EBGodunovCornerCouple::EBGodunov_corner_couple_yx(l_yxlo, l_yxhi,
                                    i, j, k, n, l_dt, dx, false,
@@ -502,7 +502,7 @@ EBGodunov::ExtrapVelToFacesOnBox ( Box const& bx, int ncomp,
         if (flag(i,j,k).isConnected(0,0,-1))
         {
         constexpr int n = 2;
-        auto bc = pbc[n];
+        const auto bc = HydroBC::getBC(i, j, k, n, domain, pbc, bc_arr);
 
         // stl is on the lo side of the lo-z side of cell (i,j,k)
         // sth is on the hi side of the lo-z side of cell (i,j,k)

--- a/EBGodunov/hydro_ebgodunov_extrap_vel_to_faces_3D.cpp
+++ b/EBGodunov/hydro_ebgodunov_extrap_vel_to_faces_3D.cpp
@@ -307,7 +307,7 @@ EBGodunov::ExtrapVelToFacesOnBox ( Box const& bx, int ncomp,
     [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
     {
         constexpr int n = 1;
-        const const auto bc = HydroBC::getBC(i, j, k, n, domain, pbc, bc_arr);
+        const auto bc = HydroBC::getBC(i, j, k, n, domain, pbc, bc_arr);
         Real l_xzlo, l_xzhi;
         EBGodunovCornerCouple::EBGodunov_corner_couple_xz(l_xzlo, l_xzhi,
                                    i, j, k, n, l_dt, dz, false,
@@ -325,7 +325,7 @@ EBGodunov::ExtrapVelToFacesOnBox ( Box const& bx, int ncomp,
     [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
     {
         constexpr int n = 1;
-        const const auto bc = HydroBC::getBC(i, j, k, n, domain, pbc, bc_arr);
+        const auto bc = HydroBC::getBC(i, j, k, n, domain, pbc, bc_arr);
         Real l_zxlo, l_zxhi;
         EBGodunovCornerCouple::EBGodunov_corner_couple_zx(l_zxlo, l_zxhi,
                                    i, j, k, n, l_dt, dx, false,
@@ -459,7 +459,7 @@ EBGodunov::ExtrapVelToFacesOnBox ( Box const& bx, int ncomp,
     [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
     {
         constexpr int n = 2;
-        const const auto bc = HydroBC::getBC(i, j, k, n, domain, pbc, bc_arr);
+        const auto bc = HydroBC::getBC(i, j, k, n, domain, pbc, bc_arr);
         Real l_xylo, l_xyhi;
         EBGodunovCornerCouple::EBGodunov_corner_couple_xy(l_xylo, l_xyhi,
                                    i, j, k, n, l_dt, dy, false,
@@ -481,7 +481,7 @@ EBGodunov::ExtrapVelToFacesOnBox ( Box const& bx, int ncomp,
     [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
     {
         constexpr int n = 2;
-        const const auto bc = HydroBC::getBC(i, j, k, n, domain, pbc, bc_arr);
+        const auto bc = HydroBC::getBC(i, j, k, n, domain, pbc, bc_arr);
         Real l_yxlo, l_yxhi;
         EBGodunovCornerCouple::EBGodunov_corner_couple_yx(l_yxlo, l_yxhi,
                                    i, j, k, n, l_dt, dx, false,

--- a/EBGodunov/hydro_ebgodunov_extrap_vel_to_faces_3D.cpp
+++ b/EBGodunov/hydro_ebgodunov_extrap_vel_to_faces_3D.cpp
@@ -47,7 +47,8 @@ EBGodunov::ExtrapVelToFacesOnBox ( Box const& bx, int ncomp,
                                    Array4<Real const> const& fcy,
                                    Array4<Real const> const& fcz,
                                    Real* p,
-                                   Array4<Real const> const& velocity_on_eb_inflow)
+                                   Array4<Real const> const& velocity_on_eb_inflow,
+                                   Array4<int const> const& dirichlet_mask)
 {
     const Dim3 dlo = amrex::lbound(domain);
     const Dim3 dhi = amrex::ubound(domain);

--- a/EBGodunov/hydro_ebgodunov_plm.H
+++ b/EBGodunov/hydro_ebgodunov_plm.H
@@ -81,7 +81,8 @@ void PredictStateOnXFace ( amrex::Box const& xebox, int ncomp,
                            amrex::Geometry const& geom,
                            amrex::Real dt,
                            amrex::Vector<amrex::BCRec> const& h_bcrec,
-                           amrex::BCRec const* pbc, bool is_velocity);
+                           amrex::BCRec const* pbc, bool is_velocity,
+                           amrex::Array4<int const> const& bc_arr = {});
 
 void PredictStateOnYFace ( amrex::Box const& yebox, int ncomp,
                            amrex::Array4<amrex::Real> const& Imy, amrex::Array4<amrex::Real> const& Ipy,
@@ -96,7 +97,8 @@ void PredictStateOnYFace ( amrex::Box const& yebox, int ncomp,
                            amrex::Geometry const& geom,
                            amrex::Real dt,
                            amrex::Vector<amrex::BCRec> const& h_bcrec,
-                           amrex::BCRec const* pbc, bool is_velocity);
+                           amrex::BCRec const* pbc, bool is_velocity,
+                           amrex::Array4<int const> const& bc_arr = {});
 
 #if (AMREX_SPACEDIM == 3)
 void PredictStateOnZFace ( amrex::Box const& zebox, int ncomp,
@@ -112,7 +114,8 @@ void PredictStateOnZFace ( amrex::Box const& zebox, int ncomp,
                            amrex::Geometry const& geom,
                            amrex::Real dt,
                            amrex::Vector<amrex::BCRec> const& h_bcrec,
-                           amrex::BCRec const* pbc, bool is_velocity);
+                           amrex::BCRec const* pbc, bool is_velocity,
+                           amrex::Array4<int const> const& bc_arr = {});
 #endif
 
 }

--- a/EBGodunov/hydro_ebgodunov_plm.H
+++ b/EBGodunov/hydro_ebgodunov_plm.H
@@ -28,7 +28,7 @@ void PredictVelOnXFace ( amrex::Box const& xebox,
                          amrex::Real dt,
                          amrex::Vector<amrex::BCRec> const& h_bcrec,
                          amrex::BCRec const* pbc,
-                         Array4<int const> const& bc_arr = {});
+                         amrex::Array4<int const> const& bc_arr = {});
 
 void PredictVelOnYFace ( amrex::Box const& yebox,
                          amrex::Array4<amrex::Real> const& Imy,
@@ -45,7 +45,7 @@ void PredictVelOnYFace ( amrex::Box const& yebox,
                          amrex::Real dt,
                          amrex::Vector<amrex::BCRec> const& h_bcrec,
                          amrex::BCRec const* pbc,
-                         Array4<int const> const& bc_arr = {});
+                         amrex::Array4<int const> const& bc_arr = {});
 
 #if (AMREX_SPACEDIM==3)
 void PredictVelOnZFace ( amrex::Box const& zebox,
@@ -63,7 +63,7 @@ void PredictVelOnZFace ( amrex::Box const& zebox,
                          amrex::Real dt,
                          amrex::Vector<amrex::BCRec> const& h_bcrec,
                          amrex::BCRec const* pbc,
-                         Array4<int const> const& bc_arr = {});
+                         amrex::Array4<int const> const& bc_arr = {});
 #endif
 
 

--- a/EBGodunov/hydro_ebgodunov_plm.H
+++ b/EBGodunov/hydro_ebgodunov_plm.H
@@ -27,7 +27,8 @@ void PredictVelOnXFace ( amrex::Box const& xebox,
                          const amrex::Geometry& geom,
                          amrex::Real dt,
                          amrex::Vector<amrex::BCRec> const& h_bcrec,
-                         amrex::BCRec const* pbc);
+                         amrex::BCRec const* pbc,
+                         Array4<int const> const& bc_arr = {});
 
 void PredictVelOnYFace ( amrex::Box const& yebox,
                          amrex::Array4<amrex::Real> const& Imy,
@@ -43,7 +44,8 @@ void PredictVelOnYFace ( amrex::Box const& yebox,
                          const amrex::Geometry& geom,
                          amrex::Real dt,
                          amrex::Vector<amrex::BCRec> const& h_bcrec,
-                         amrex::BCRec const* pbc);
+                         amrex::BCRec const* pbc,
+                         Array4<int const> const& bc_arr = {});
 
 #if (AMREX_SPACEDIM==3)
 void PredictVelOnZFace ( amrex::Box const& zebox,
@@ -60,7 +62,8 @@ void PredictVelOnZFace ( amrex::Box const& zebox,
                          const amrex::Geometry& geom,
                          amrex::Real dt,
                          amrex::Vector<amrex::BCRec> const& h_bcrec,
-                         amrex::BCRec const* pbc);
+                         amrex::BCRec const* pbc,
+                         Array4<int const> const& bc_arr = {});
 #endif
 
 

--- a/EBGodunov/hydro_ebgodunov_plm.cpp
+++ b/EBGodunov/hydro_ebgodunov_plm.cpp
@@ -85,10 +85,10 @@ EBPLM::PredictVelOnXFace (Box const& xebox,
     if ( (has_extdir_or_ho_lo_x && touch_dilo) ||
          (has_extdir_or_ho_hi_x && touch_dihi) ||
          (has_extdir_or_ho_lo_y && touch_djlo) ||
-         (has_extdir_or_ho_hi_y && touch_djhi) ||
+         (has_extdir_or_ho_hi_y && touch_djhi)
 #if (AMREX_SPACEDIM == 3)
-         (has_extdir_or_ho_lo_z && touch_dklo) ||
-         (has_extdir_or_ho_hi_z && touch_dkhi) ||
+         || (has_extdir_or_ho_lo_z && touch_dklo)
+         || (has_extdir_or_ho_hi_z && touch_dkhi)
 #endif
         )
     {
@@ -452,10 +452,10 @@ EBPLM::PredictVelOnYFace (Box const& yebox,
     if ( (has_extdir_or_ho_lo_x && touch_dilo) ||
          (has_extdir_or_ho_hi_x && touch_dihi) ||
          (has_extdir_or_ho_lo_y && touch_djlo) ||
-         (has_extdir_or_ho_hi_y && touch_djhi) ||
+         (has_extdir_or_ho_hi_y && touch_djhi)
 #if (AMREX_SPACEDIM == 3)
-         (has_extdir_or_ho_lo_z && touch_dklo) ||
-         (has_extdir_or_ho_hi_z && touch_dkhi) ||
+         || (has_extdir_or_ho_lo_z && touch_dklo)
+         || (has_extdir_or_ho_hi_z && touch_dkhi)
 #endif
         )
     {
@@ -818,8 +818,7 @@ EBPLM::PredictVelOnZFace (Box const& zebox,
          (has_extdir_or_ho_lo_y && touch_djlo) ||
          (has_extdir_or_ho_hi_y && touch_djhi) ||
          (has_extdir_or_ho_lo_z && touch_dklo) ||
-         (has_extdir_or_ho_hi_z && touch_dkhi) ||
-        )
+         (has_extdir_or_ho_hi_z && touch_dkhi) )
     {
         amrex::ParallelFor(zebox, ncomp, [=]
         AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept

--- a/Godunov/hydro_godunov.H
+++ b/Godunov/hydro_godunov.H
@@ -43,7 +43,8 @@ void ComputeAdvectiveVel (AMREX_D_DECL(amrex::Box const& xbx,
                           const amrex::Box& domain,
                           amrex::Real dt,
                           amrex::BCRec const* pbc,
-                          bool use_forces_in_trans);
+                          bool use_forces_in_trans,
+                          amrex::Array4<int const> const& bc_arr = {});
 
 void ExtrapVelToFacesOnBox (amrex::Box const& bx, int ncomp,
                             AMREX_D_DECL(amrex::Box const& xbx,
@@ -68,7 +69,8 @@ void ExtrapVelToFacesOnBox (amrex::Box const& bx, int ncomp,
                             amrex::Real dt,
                             amrex::BCRec const* pbc,
                             bool use_forces_in_trans,
-                            amrex::Real* p);
+                            amrex::Real* p,
+                            amrex::Array4<int const> const& bc_arr = {});
 
 void ComputeEdgeState ( amrex::Box const& bx, int ncomp,
                         amrex::Array4<amrex::Real const> const& q,

--- a/Godunov/hydro_godunov.H
+++ b/Godunov/hydro_godunov.H
@@ -24,7 +24,8 @@ void ExtrapVelToFaces ( amrex::MultiFab const& a_vel,
                         const               amrex::BCRec  * d_bcrec,
                         const amrex::Geometry& geom, amrex::Real l_dt,
                         bool use_ppm, bool use_forces_in_trans,
-                        int limiter_type = PPM::VanLeer);
+                        int limiter_type = PPM::VanLeer,
+                        amrex::iMultiFab const* BC_MF = nullptr);
 
 void ComputeAdvectiveVel (AMREX_D_DECL(amrex::Box const& xbx,
                                        amrex::Box const& ybx,
@@ -88,7 +89,8 @@ void ComputeEdgeState ( amrex::Box const& bx, int ncomp,
                         int const* iconserv,
                         bool use_ppm, bool use_forces_in_trans,
                         bool is_velocity,
-                        int limiter_type = PPM::VanLeer);
+                        int limiter_type = PPM::VanLeer,
+                        amrex::Array4<int const> const& bc_arr = {});
 
 }
 

--- a/Godunov/hydro_godunov_edge_state_3D.cpp
+++ b/Godunov/hydro_godunov_edge_state_3D.cpp
@@ -30,7 +30,8 @@ Godunov::ComputeEdgeState (Box const& bx, int ncomp,
                            const bool use_ppm,
                            const bool use_forces_in_trans,
                            const bool is_velocity,
-                           const int limiter_type)
+                           const int limiter_type,
+                           amrex::Array4<int const> const& bc_arr)
 {
     Box const& xbx = amrex::surroundingNodes(bx,0);
     Box const& ybx = amrex::surroundingNodes(bx,1);
@@ -115,21 +116,24 @@ Godunov::ComputeEdgeState (Box const& bx, int ncomp,
         amrex::ParallelFor(xebox, ncomp,
         [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
         {
+            const auto bc = HydroBC::getBC(i, j, k, n, domain, pbc, bc_arr);
             PLM::PredictStateOnXFace(i, j, k, n, l_dt, dx, Imx(i,j,k,n), Ipx(i-1,j,k,n),
-                                     q, umac(i,j,k), pbc[n], dlo.x, dhi.x, is_velocity);
+                                     q, umac(i,j,k), bc, dlo.x, dhi.x, is_velocity);
         });
 
         amrex::ParallelFor(yebox, ncomp,
         [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
         {
+            const auto bc = HydroBC::getBC(i, j, k, n, domain, pbc, bc_arr);
             PLM::PredictStateOnYFace(i, j, k, n, l_dt, dy, Imy(i,j,k,n), Ipy(i,j-1,k,n),
-                                     q, vmac(i,j,k), pbc[n], dlo.y, dhi.y, is_velocity);
+                                     q, vmac(i,j,k), bc, dlo.y, dhi.y, is_velocity);
         });
         amrex::ParallelFor(zebox, ncomp,
         [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
         {
+            const auto bc = HydroBC::getBC(i, j, k, n, domain, pbc, bc_arr);
             PLM::PredictStateOnZFace(i, j, k, n, l_dt, dz, Imz(i,j,k,n), Ipz(i,j,k-1,n),
-                                     q, wmac(i,j,k), pbc[n], dlo.z, dhi.z, is_velocity);
+                                     q, wmac(i,j,k), bc, dlo.z, dhi.z, is_velocity);
         });
     }
 
@@ -149,7 +153,7 @@ Godunov::ComputeEdgeState (Box const& bx, int ncomp,
             hi += 0.5*l_dt*fq(i  ,j,k,n);
         }
 
-        auto bc = pbc[n];
+        const auto bc = HydroBC::getBC(i, j, k, n, domain, pbc, bc_arr);
 
         HydroBC::SetXEdgeBCs(i, j, k, n, q, lo, hi, bc.lo(0), dlo.x, bc.hi(0), dhi.x, is_velocity);
         xlo(i,j,k,n) = lo;
@@ -172,7 +176,7 @@ Godunov::ComputeEdgeState (Box const& bx, int ncomp,
             hi += 0.5*l_dt*fq(i,j  ,k,n);
         }
 
-        auto bc = pbc[n];
+        const auto bc = HydroBC::getBC(i, j, k, n, domain, pbc, bc_arr);
 
         HydroBC::SetYEdgeBCs(i, j, k, n, q, lo, hi, bc.lo(1), dlo.y, bc.hi(1), dhi.y, is_velocity);
 
@@ -195,7 +199,7 @@ Godunov::ComputeEdgeState (Box const& bx, int ncomp,
             hi += 0.5*l_dt*fq(i,j,k  ,n);
         }
 
-        auto bc = pbc[n];
+        const auto bc = HydroBC::getBC(i, j, k, n, domain, pbc, bc_arr);
 
         HydroBC::SetZEdgeBCs(i, j, k, n, q, lo, hi, bc.lo(2), dlo.z, bc.hi(2), dhi.z, is_velocity);
 
@@ -218,7 +222,7 @@ Godunov::ComputeEdgeState (Box const& bx, int ncomp,
     Box(zylo), ncomp,
     [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
     {
-        const auto bc = pbc[n];
+        const auto bc = HydroBC::getBC(i, j, k, n, domain, pbc, bc_arr);
         Real l_zylo, l_zyhi;
         GodunovCornerCouple::AddCornerCoupleTermZY(l_zylo, l_zyhi,
                               i, j, k, n, l_dt, dy, iconserv[n],
@@ -235,7 +239,7 @@ Godunov::ComputeEdgeState (Box const& bx, int ncomp,
     Box(yzlo), ncomp,
     [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
     {
-        const auto bc = pbc[n];
+        const auto bc = HydroBC::getBC(i, j, k, n, domain, pbc, bc_arr);
         Real l_yzlo, l_yzhi;
         GodunovCornerCouple::AddCornerCoupleTermYZ(l_yzlo, l_yzhi,
                               i, j, k, n, l_dt, dz, iconserv[n],
@@ -255,43 +259,43 @@ Godunov::ComputeEdgeState (Box const& bx, int ncomp,
     amrex::ParallelFor(xbx, ncomp,
     [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
     {
-    Real stl = xlo(i,j,k,n);
-    Real sth = xhi(i,j,k,n);
+        Real stl = xlo(i,j,k,n);
+        Real sth = xhi(i,j,k,n);
 
         // To match EBGodunov
         // Here we add  dt/2 (-q u_x - (v q)_y - (w q)_z) to the term that is already
-    //     q + dx/2 q_x + dt/2 (-u q_x) to get
-    //     q + dx/2 q_x - dt/2 (u q_x  + q u_x + (v q)_y + (w q)_z) which is equivalent to
-    // --> q + dx/2 q_x - dt/2 ( div (uvec q) )
-    Real quxl = (umac(i,j,k) - umac(i-1,j,k)) * q(i-1,j,k,n);
-    stl += ( - (0.5*dtdx) * quxl
-         - (0.5*dtdy)*(yzlo(i-1,j+1,k  ,n)*vmac(i-1,j+1,k  )
-                     - yzlo(i-1,j  ,k  ,n)*vmac(i-1,j  ,k  ))
-         - (0.5*dtdz)*(zylo(i-1,j  ,k+1,n)*wmac(i-1,j  ,k+1)
-                   - zylo(i-1,j  ,k  ,n)*wmac(i-1,j  ,k  )) );
+        //     q + dx/2 q_x + dt/2 (-u q_x) to get
+        //     q + dx/2 q_x - dt/2 (u q_x  + q u_x + (v q)_y + (w q)_z) which is equivalent to
+        // --> q + dx/2 q_x - dt/2 ( div (uvec q) )
+        Real quxl = (umac(i,j,k) - umac(i-1,j,k)) * q(i-1,j,k,n);
+        stl += ( - (0.5*dtdx) * quxl
+                 - (0.5*dtdy)*(yzlo(i-1,j+1,k  ,n)*vmac(i-1,j+1,k  )
+                               - yzlo(i-1,j  ,k  ,n)*vmac(i-1,j  ,k  ))
+                 - (0.5*dtdz)*(zylo(i-1,j  ,k+1,n)*wmac(i-1,j  ,k+1)
+                               - zylo(i-1,j  ,k  ,n)*wmac(i-1,j  ,k  )) );
 
-    // Here we adjust for non-conservative by removing the q divu contribution to get
-    //     q + dx/2 q_x - dt/2 ( div (uvec q) - q divu ) which is equivalent to
-    // --> q + dx/2 q_x - dt/2 ( uvec dot grad q)
-    stl += (!iconserv[n])               ? 0.5*l_dt* q(i-1,j,k,n)*divu(i-1,j,k) : 0.;
+        // Here we adjust for non-conservative by removing the q divu contribution to get
+        //     q + dx/2 q_x - dt/2 ( div (uvec q) - q divu ) which is equivalent to
+        // --> q + dx/2 q_x - dt/2 ( uvec dot grad q)
+        stl += (!iconserv[n])               ? 0.5*l_dt* q(i-1,j,k,n)*divu(i-1,j,k) : 0.;
 
-    stl += (!use_forces_in_trans && fq) ? 0.5*l_dt*fq(i-1,j,k,n) : 0.;
+        stl += (!use_forces_in_trans && fq) ? 0.5*l_dt*fq(i-1,j,k,n) : 0.;
 
-    // High side
-    Real quxh = (umac(i+1,j,k) - umac(i,j,k)) * q(i,j,k,n);
-    sth += ( - (0.5*dtdx) * quxh
-         - (0.5*dtdy)*(yzlo(i,j+1,k  ,n)*vmac(i,j+1,k  )
-                     - yzlo(i,j  ,k  ,n)*vmac(i,j  ,k  ))
-         - (0.5*dtdz)*(zylo(i,j  ,k+1,n)*wmac(i,j  ,k+1)
-                         - zylo(i,j  ,k  ,n)*wmac(i,j  ,k  )) );
+        // High side
+        Real quxh = (umac(i+1,j,k) - umac(i,j,k)) * q(i,j,k,n);
+        sth += ( - (0.5*dtdx) * quxh
+                 - (0.5*dtdy)*(yzlo(i,j+1,k  ,n)*vmac(i,j+1,k  )
+                               - yzlo(i,j  ,k  ,n)*vmac(i,j  ,k  ))
+                 - (0.5*dtdz)*(zylo(i,j  ,k+1,n)*wmac(i,j  ,k+1)
+                               - zylo(i,j  ,k  ,n)*wmac(i,j  ,k  )) );
 
-    sth += (!iconserv[n])               ? 0.5*l_dt* q(i  ,j,k,n)*divu(i,j,k) : 0.;
+        sth += (!iconserv[n])               ? 0.5*l_dt* q(i  ,j,k,n)*divu(i,j,k) : 0.;
 
-    sth += (!use_forces_in_trans && fq) ? 0.5*l_dt*fq(i  ,j,k,n) : 0.;
+        sth += (!use_forces_in_trans && fq) ? 0.5*l_dt*fq(i  ,j,k,n) : 0.;
 
 
-    auto bc = pbc[n];
-    HydroBC::SetXEdgeBCs(i, j, k, n, q, stl, sth, bc.lo(0), dlo.x, bc.hi(0), dhi.x, is_velocity);
+        const auto bc = HydroBC::getBC(i, j, k, n, domain, pbc, bc_arr);
+        HydroBC::SetXEdgeBCs(i, j, k, n, q, stl, sth, bc.lo(0), dlo.x, bc.hi(0), dhi.x, is_velocity);
 
         if ( (i==dlo.x) && (bc.lo(0) == BCType::foextrap || bc.lo(0) == BCType::hoextrap) )
         {
@@ -319,7 +323,7 @@ Godunov::ComputeEdgeState (Box const& bx, int ncomp,
     Box(xzlo), ncomp,
     [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
     {
-        const auto bc = pbc[n];
+        const auto bc = HydroBC::getBC(i, j, k, n, domain, pbc, bc_arr);
         Real l_xzlo, l_xzhi;
         GodunovCornerCouple::AddCornerCoupleTermXZ(l_xzlo, l_xzhi,
                               i, j, k, n, l_dt, dz, iconserv[n],
@@ -336,7 +340,7 @@ Godunov::ComputeEdgeState (Box const& bx, int ncomp,
     Box(zxlo), ncomp,
     [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
     {
-        const auto bc = pbc[n];
+        const auto bc = HydroBC::getBC(i, j, k, n, domain, pbc, bc_arr);
         Real l_zxlo, l_zxhi;
         GodunovCornerCouple::AddCornerCoupleTermZX(l_zxlo, l_zxhi,
                               i, j, k, n, l_dt, dx, iconserv[n],
@@ -355,41 +359,41 @@ Godunov::ComputeEdgeState (Box const& bx, int ncomp,
     amrex::ParallelFor(ybx, ncomp,
     [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
     {
-    Real stl = ylo(i,j,k,n);
-    Real sth = yhi(i,j,k,n);
+        Real stl = ylo(i,j,k,n);
+        Real sth = yhi(i,j,k,n);
 
-    // Here we add  dt/2 (-q v_y - (u q)_x - (w q)_z) to the term that is already
-    //     q + dy/2 q_y + dt/2 (-v q_y) to get
-    //     q + dy/2 q_y - dt/2 (v q_y  + q v_y + (u q)_x + (w q)_z) which is equivalent to
-    // --> q + dy/2 q_y - dt/2 ( div (uvec q) )
-    Real qvyl = (vmac(i,j,k) - vmac(i,j-1,k)) * q(i,j-1,k,n);
-    stl += ( - (0.5*dtdy) * qvyl
-         - (0.5*dtdx)*(xzlo(i+1,j-1,k  ,n)*umac(i+1,j-1,k  )
-                 - xzlo(i  ,j-1,k  ,n)*umac(i  ,j-1,k  ))
-         - (0.5*dtdz)*(zxlo(i  ,j-1,k+1,n)*wmac(i  ,j-1,k+1)
-                 - zxlo(i  ,j-1,k  ,n)*wmac(i  ,j-1,k  )) );
+        // Here we add  dt/2 (-q v_y - (u q)_x - (w q)_z) to the term that is already
+        //     q + dy/2 q_y + dt/2 (-v q_y) to get
+        //     q + dy/2 q_y - dt/2 (v q_y  + q v_y + (u q)_x + (w q)_z) which is equivalent to
+        // --> q + dy/2 q_y - dt/2 ( div (uvec q) )
+        Real qvyl = (vmac(i,j,k) - vmac(i,j-1,k)) * q(i,j-1,k,n);
+        stl += ( - (0.5*dtdy) * qvyl
+                 - (0.5*dtdx)*(xzlo(i+1,j-1,k  ,n)*umac(i+1,j-1,k  )
+                               - xzlo(i  ,j-1,k  ,n)*umac(i  ,j-1,k  ))
+                 - (0.5*dtdz)*(zxlo(i  ,j-1,k+1,n)*wmac(i  ,j-1,k+1)
+                               - zxlo(i  ,j-1,k  ,n)*wmac(i  ,j-1,k  )) );
 
-    // Here we adjust for non-conservative by removing the q divu contribution to get
-    //     q + dy/2 q_y - dt/2 ( div (uvec q) - q divu ) which is equivalent to
-    // --> q + dy/2 q_y - dt/2 ( uvec dot grad q)
-    stl += (!iconserv[n]) ? 0.5*l_dt* q(i,j-1,k,n)*divu(i,j-1,k) : 0.;
+        // Here we adjust for non-conservative by removing the q divu contribution to get
+        //     q + dy/2 q_y - dt/2 ( div (uvec q) - q divu ) which is equivalent to
+        // --> q + dy/2 q_y - dt/2 ( uvec dot grad q)
+        stl += (!iconserv[n]) ? 0.5*l_dt* q(i,j-1,k,n)*divu(i,j-1,k) : 0.;
 
-    stl += (!use_forces_in_trans && fq)           ? 0.5*l_dt*fq(i,j-1,k,n) : 0.;
+        stl += (!use_forces_in_trans && fq)           ? 0.5*l_dt*fq(i,j-1,k,n) : 0.;
 
-    // High side
-    Real qvyh = (vmac(i,j+1,k) - vmac(i,j,k)) * q(i,j,k,n);
-    sth += ( - (0.5*dtdy) * qvyh
-         - (0.5*dtdx)*(xzlo(i+1,j,k  ,n)*umac(i+1,j,k  )
-                 - xzlo(i  ,j,k  ,n)*umac(i  ,j,k  ))
-         - (0.5*dtdz)*(zxlo(i  ,j,k+1,n)*wmac(i  ,j,k+1)
-                     - zxlo(i  ,j,k  ,n)*wmac(i  ,j,k  )) );
+        // High side
+        Real qvyh = (vmac(i,j+1,k) - vmac(i,j,k)) * q(i,j,k,n);
+        sth += ( - (0.5*dtdy) * qvyh
+                 - (0.5*dtdx)*(xzlo(i+1,j,k  ,n)*umac(i+1,j,k  )
+                               - xzlo(i  ,j,k  ,n)*umac(i  ,j,k  ))
+                 - (0.5*dtdz)*(zxlo(i  ,j,k+1,n)*wmac(i  ,j,k+1)
+                               - zxlo(i  ,j,k  ,n)*wmac(i  ,j,k  )) );
 
-    sth += (!iconserv[n])               ? 0.5*l_dt* q(i,j,k,n)*divu(i,j,k) : 0.;
+        sth += (!iconserv[n])               ? 0.5*l_dt* q(i,j,k,n)*divu(i,j,k) : 0.;
 
-    sth += (!use_forces_in_trans && fq) ? 0.5*l_dt*fq(i,j,k,n) : 0.;
+        sth += (!use_forces_in_trans && fq) ? 0.5*l_dt*fq(i,j,k,n) : 0.;
 
 
-        auto bc = pbc[n];
+        const auto bc = HydroBC::getBC(i, j, k, n, domain, pbc, bc_arr);
         HydroBC::SetYEdgeBCs(i, j, k, n, q, stl, sth, bc.lo(1), dlo.y, bc.hi(1), dhi.y, is_velocity);
 
         if ( (j==dlo.y) && (bc.lo(1) == BCType::foextrap || bc.lo(1) == BCType::hoextrap) )
@@ -418,7 +422,7 @@ Godunov::ComputeEdgeState (Box const& bx, int ncomp,
     Box(xylo), ncomp,
     [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
     {
-        const auto bc = pbc[n];
+        const auto bc = HydroBC::getBC(i, j, k, n, domain, pbc, bc_arr);
         Real l_xylo, l_xyhi;
         GodunovCornerCouple::AddCornerCoupleTermXY(l_xylo, l_xyhi,
                               i, j, k, n, l_dt, dy, iconserv[n],
@@ -435,7 +439,7 @@ Godunov::ComputeEdgeState (Box const& bx, int ncomp,
     Box(yxlo), ncomp,
     [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
     {
-        const auto bc = pbc[n];
+        const auto bc = HydroBC::getBC(i, j, k, n, domain, pbc, bc_arr);
         Real l_yxlo, l_yxhi;
         GodunovCornerCouple::AddCornerCoupleTermYX(l_yxlo, l_yxhi,
                               i, j, k, n, l_dt, dx, iconserv[n],
@@ -455,41 +459,41 @@ Godunov::ComputeEdgeState (Box const& bx, int ncomp,
     [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
     {
         Real stl = zlo(i,j,k,n);
-    Real sth = zhi(i,j,k,n);
+        Real sth = zhi(i,j,k,n);
 
-    // Here we add  dt/2 (-q w_z - (u q)_x - (v q)_y) to the term that is already
-    //     q + dz/2 q_z + dt/2 (-w q_z) to get
-    //     q + dz/2 q_z - dt/2 (w q_z  + q w_z + (u q)_x + (v q)_y) which is equivalent to
-    // --> q + dz/2 q_z - dt/2 ( div (uvec q) )
-    Real qwzl = (wmac(i,j,k) - wmac(i,j,k-1)) * q(i,j,k-1,n);
-    stl += ( - (0.5*dtdz) * qwzl
-         - (0.5*dtdx)*(xylo(i+1,j  ,k-1,n)*umac(i+1,j  ,k-1)
-                  -xylo(i  ,j  ,k-1,n)*umac(i  ,j  ,k-1))
-         - (0.5*dtdy)*(yxlo(i  ,j+1,k-1,n)*vmac(i  ,j+1,k-1)
-                  -yxlo(i  ,j  ,k-1,n)*vmac(i  ,j  ,k-1)) );
+        // Here we add  dt/2 (-q w_z - (u q)_x - (v q)_y) to the term that is already
+        //     q + dz/2 q_z + dt/2 (-w q_z) to get
+        //     q + dz/2 q_z - dt/2 (w q_z  + q w_z + (u q)_x + (v q)_y) which is equivalent to
+        // --> q + dz/2 q_z - dt/2 ( div (uvec q) )
+        Real qwzl = (wmac(i,j,k) - wmac(i,j,k-1)) * q(i,j,k-1,n);
+        stl += ( - (0.5*dtdz) * qwzl
+                 - (0.5*dtdx)*(xylo(i+1,j  ,k-1,n)*umac(i+1,j  ,k-1)
+                               -xylo(i  ,j  ,k-1,n)*umac(i  ,j  ,k-1))
+                 - (0.5*dtdy)*(yxlo(i  ,j+1,k-1,n)*vmac(i  ,j+1,k-1)
+                               -yxlo(i  ,j  ,k-1,n)*vmac(i  ,j  ,k-1)) );
 
-    // Here we adjust for non-conservative by removing the q divu contribution to get
-    //     q + dz/2 q_z - dt/2 ( div (uvec q) - q divu ) which is equivalent to
-    // --> q + dz/2 q_z - dt/2 ( uvec dot grad q)
-    stl += (!iconserv[n])               ? 0.5*l_dt* q(i,j,k-1,n)*divu(i,j,k-1) : 0.;
+        // Here we adjust for non-conservative by removing the q divu contribution to get
+        //     q + dz/2 q_z - dt/2 ( div (uvec q) - q divu ) which is equivalent to
+        // --> q + dz/2 q_z - dt/2 ( uvec dot grad q)
+        stl += (!iconserv[n])               ? 0.5*l_dt* q(i,j,k-1,n)*divu(i,j,k-1) : 0.;
 
-    stl += (!use_forces_in_trans && fq) ? 0.5*l_dt*fq(i,j,k-1,n) : 0.;
+        stl += (!use_forces_in_trans && fq) ? 0.5*l_dt*fq(i,j,k-1,n) : 0.;
 
-    // High side
-    Real qwzh = (wmac(i,j,k+1) - wmac(i,j,k)) * q(i,j,k,n);
-    sth += ( - (0.5*dtdz) * qwzh
-         - (0.5*dtdx)*(xylo(i+1,j  ,k,n)*umac(i+1,j  ,k)
-                  -xylo(i  ,j  ,k,n)*umac(i  ,j  ,k))
-         - (0.5*dtdy)*(yxlo(i  ,j+1,k,n)*vmac(i  ,j+1,k)
-                  -yxlo(i  ,j  ,k,n)*vmac(i  ,j  ,k)) );
+        // High side
+        Real qwzh = (wmac(i,j,k+1) - wmac(i,j,k)) * q(i,j,k,n);
+        sth += ( - (0.5*dtdz) * qwzh
+                 - (0.5*dtdx)*(xylo(i+1,j  ,k,n)*umac(i+1,j  ,k)
+                               -xylo(i  ,j  ,k,n)*umac(i  ,j  ,k))
+                 - (0.5*dtdy)*(yxlo(i  ,j+1,k,n)*vmac(i  ,j+1,k)
+                               -yxlo(i  ,j  ,k,n)*vmac(i  ,j  ,k)) );
 
-    sth += (!iconserv[n])               ? 0.5*l_dt* q(i,j,k,n)*divu(i,j,k) : 0.;
+        sth += (!iconserv[n])               ? 0.5*l_dt* q(i,j,k,n)*divu(i,j,k) : 0.;
 
-    sth += (!use_forces_in_trans && fq) ? 0.5*l_dt*fq(i,j,k,n) : 0.;
+        sth += (!use_forces_in_trans && fq) ? 0.5*l_dt*fq(i,j,k,n) : 0.;
 
 
 
-        auto bc = pbc[n];
+        const auto bc = HydroBC::getBC(i, j, k, n, domain, pbc, bc_arr);
         HydroBC::SetZEdgeBCs(i, j, k, n, q, stl, sth, bc.lo(2), dlo.z, bc.hi(2), dhi.z, is_velocity);
 
         if ( (k==dlo.z) && (bc.lo(2) == BCType::foextrap || bc.lo(2) == BCType::hoextrap) )

--- a/Godunov/hydro_godunov_extrap_vel_to_faces_2D.cpp
+++ b/Godunov/hydro_godunov_extrap_vel_to_faces_2D.cpp
@@ -122,7 +122,8 @@ Godunov::ComputeAdvectiveVel ( Box const& xbx,
                                const Box& domain,
                                Real l_dt,
                                BCRec  const* pbc,
-                               bool l_use_forces_in_trans )
+                               bool l_use_forces_in_trans,
+                               Array4<int const> const& bc_arr)
 {
     const Dim3 dlo = amrex::lbound(domain);
     const Dim3 dhi = amrex::ubound(domain);
@@ -192,7 +193,8 @@ Godunov::ExtrapVelToFacesOnBox (Box const& bx, int ncomp,
                                 Real l_dt,
                                 BCRec  const* pbc,
                                 bool l_use_forces_in_trans,
-                                Real* p)
+                                Real* p,
+                                Array4<int const> const& bc_arr)
 {
 
     const Dim3 dlo = amrex::lbound(domain);

--- a/Godunov/hydro_godunov_extrap_vel_to_faces_2D.cpp
+++ b/Godunov/hydro_godunov_extrap_vel_to_faces_2D.cpp
@@ -143,7 +143,7 @@ Godunov::ComputeAdvectiveVel ( Box const& xbx,
             hi += 0.5*l_dt*f(i  ,j,k,n);
         }
 
-        auto bc = pbc[n];
+        const auto bc = HydroBC::getBC(i, j, k, n, domain, pbc, bc_arr);
         HydroBC::SetXEdgeBCs(i, j, k, n, vel, lo, hi, bc.lo(0), dlo.x, bc.hi(0), dhi.x, true);
 
         Real st = ( (lo+hi) >= 0.) ? lo : hi;
@@ -164,7 +164,7 @@ Godunov::ComputeAdvectiveVel ( Box const& xbx,
             hi += 0.5*l_dt*f(i,j  ,k,n);
         }
 
-        auto bc = pbc[n];
+        const auto bc = HydroBC::getBC(i, j, k, n, domain, pbc, bc_arr);
         HydroBC::SetYEdgeBCs(i, j, k, n, vel, lo, hi, bc.lo(1), dlo.y, bc.hi(1), dhi.y, true);
 
         Real st = ( (lo+hi) >= 0.) ? lo : hi;
@@ -230,7 +230,7 @@ Godunov::ExtrapVelToFacesOnBox (Box const& bx, int ncomp,
             hi += 0.5*l_dt*f(i  ,j,k,n);
         }
 
-        auto bc = pbc[n];
+        const auto bc = HydroBC::getBC(i, j, k, n, domain, pbc, bc_arr);
         HydroBC::SetXEdgeBCs(i, j, k, n, q, lo, hi, bc.lo(0), dlo.x, bc.hi(0), dhi.x, true);
 
         xlo(i,j,k,n) = lo;
@@ -247,7 +247,7 @@ Godunov::ExtrapVelToFacesOnBox (Box const& bx, int ncomp,
             hi += 0.5*l_dt*f(i,j  ,k,n);
         }
 
-        auto bc = pbc[n];
+        const auto bc = HydroBC::getBC(i, j, k, n, domain, pbc, bc_arr);
         HydroBC::SetYEdgeBCs(i, j, k, n, q, lo, hi, bc.lo(1), dlo.y, bc.hi(1), dhi.y, true);
 
         ylo(i,j,k,n) = lo;
@@ -265,7 +265,7 @@ Godunov::ExtrapVelToFacesOnBox (Box const& bx, int ncomp,
     [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
     {
         constexpr int n = 0;
-        const auto bc = pbc[n];
+        const const auto bc = HydroBC::getBC(i, j, k, n, domain, pbc, bc_arr);
         Real l_yzlo, l_yzhi;
 
         l_yzlo = ylo(i,j,k,n);
@@ -282,7 +282,7 @@ Godunov::ExtrapVelToFacesOnBox (Box const& bx, int ncomp,
     amrex::ParallelFor(xbx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
     {
         constexpr int n = 0;
-        auto bc = pbc[n];
+        const auto bc = HydroBC::getBC(i, j, k, n, domain, pbc, bc_arr);
         Real stl = xlo(i,j,k,n) - (0.25*l_dt/dy)*(v_ad(i-1,j+1,k  )+v_ad(i-1,j,k))*
                                                  (yzlo(i-1,j+1,k  )-yzlo(i-1,j,k));
         Real sth = xhi(i,j,k,n) - (0.25*l_dt/dy)*(v_ad(i  ,j+1,k  )+v_ad(i  ,j,k))*
@@ -321,7 +321,7 @@ Godunov::ExtrapVelToFacesOnBox (Box const& bx, int ncomp,
     [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
     {
         constexpr int n = 1;
-        const auto bc = pbc[n];
+        const const auto bc = HydroBC::getBC(i, j, k, n, domain, pbc, bc_arr);
         Real l_xzlo, l_xzhi;
 
         l_xzlo = xlo(i,j,k,n);
@@ -340,7 +340,7 @@ Godunov::ExtrapVelToFacesOnBox (Box const& bx, int ncomp,
     amrex::ParallelFor(ybx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
     {
         constexpr int n = 1;
-        auto bc = pbc[n];
+        const auto bc = HydroBC::getBC(i, j, k, n, domain, pbc, bc_arr);
 
         Real stl = ylo(i,j,k,n) - (0.25*l_dt/dx)*(u_ad(i+1,j-1,k  )+u_ad(i,j-1,k))*
                                                  (xzlo(i+1,j-1,k  )-xzlo(i,j-1,k));

--- a/Godunov/hydro_godunov_extrap_vel_to_faces_2D.cpp
+++ b/Godunov/hydro_godunov_extrap_vel_to_faces_2D.cpp
@@ -89,7 +89,7 @@ Godunov::ExtrapVelToFaces ( MultiFab const& a_vel,
             else
             {
                 PLM::PredictVelOnXFace( Box(u_ad), AMREX_SPACEDIM, Imx, Ipx, vel, vel,
-                                         geom, l_dt, h_bcrec, d_bcrec);
+                                        geom, l_dt, h_bcrec, d_bcrec);
                 PLM::PredictVelOnYFace( Box(v_ad), AMREX_SPACEDIM, Imy, Ipy, vel, vel,
                                         geom, l_dt, h_bcrec, d_bcrec);
             }

--- a/Godunov/hydro_godunov_extrap_vel_to_faces_3D.cpp
+++ b/Godunov/hydro_godunov_extrap_vel_to_faces_3D.cpp
@@ -139,7 +139,8 @@ Godunov::ComputeAdvectiveVel ( Box const& xbx,
                                const Box& domain,
                                Real l_dt,
                                BCRec  const* pbc,
-                               bool l_use_forces_in_trans)
+                               bool l_use_forces_in_trans,
+                               Array4<int const> const& bc_arr)
 {
     const Dim3 dlo = amrex::lbound(domain);
     const Dim3 dhi = amrex::ubound(domain);
@@ -235,7 +236,8 @@ Godunov::ExtrapVelToFacesOnBox ( Box const& bx, int ncomp,
                                  Real l_dt,
                                  BCRec  const* pbc,
                                  bool l_use_forces_in_trans,
-                                 Real* p)
+                                 Real* p,
+                                 Array4<int const> const& bc_arr)
 {
 
     const Dim3 dlo = amrex::lbound(domain);

--- a/Godunov/hydro_godunov_plm.H
+++ b/Godunov/hydro_godunov_plm.H
@@ -26,7 +26,8 @@ void PredictVelOnXFace ( amrex::Box const& xebox, int ncomp,
                          const amrex::Geometry& geom,
                          amrex::Real dt,
                          amrex::Vector<amrex::BCRec> const& h_bcrec,
-                         amrex::BCRec const* pbc);
+                         amrex::BCRec const* pbc,
+                         amrex::Array4<int const> const& bc_arr = {});
 
 void PredictVelOnYFace ( amrex::Box const& yebox, int ncomp,
                          amrex::Array4<amrex::Real> const& Imy, amrex::Array4<amrex::Real> const& Ipy,
@@ -35,7 +36,8 @@ void PredictVelOnYFace ( amrex::Box const& yebox, int ncomp,
                          const amrex::Geometry& geom,
                          amrex::Real dt,
                          amrex::Vector<amrex::BCRec> const& h_bcrec,
-                         amrex::BCRec const* pbc);
+                         amrex::BCRec const* pbc,
+                         amrex::Array4<int const> const& bc_arr= {});
 
 #if (AMREX_SPACEDIM==3)
 void PredictVelOnZFace ( amrex::Box const& zebox, int ncomp,
@@ -45,7 +47,8 @@ void PredictVelOnZFace ( amrex::Box const& zebox, int ncomp,
                          const amrex::Geometry& geom,
                          amrex::Real dt,
                          amrex::Vector<amrex::BCRec> const& h_bcrec,
-                         amrex::BCRec const* pbc);
+                         amrex::BCRec const* pbc,
+                         amrex::Array4<int const> const& bc_arr= {});
 #endif
 
 

--- a/Godunov/hydro_godunov_plm.cpp
+++ b/Godunov/hydro_godunov_plm.cpp
@@ -36,7 +36,8 @@ PLM::PredictVelOnXFace ( Box const& xebox, int ncomp,
                          const Geometry& geom,
                          Real dt,
                          Vector<BCRec> const& h_bcrec,
-                         BCRec const* pbc)
+                         BCRec const* pbc,
+                         Array4<int const> const& bc_arr)
 {
     const Real dx = geom.CellSize(0);
     const Real dtdx = dt/dx;
@@ -99,7 +100,8 @@ PLM::PredictVelOnYFace (Box const& yebox, int ncomp,
                         const Geometry& geom,
                         Real dt,
                         Vector<BCRec> const& h_bcrec,
-                        BCRec const* pbc)
+                        BCRec const* pbc,
+                        Array4<int const> const& bc_arr)
 {
     const Real dy = geom.CellSize(1);
     const Real dtdy = dt/dy;
@@ -163,7 +165,8 @@ PLM::PredictVelOnZFace ( Box const& zebox, int ncomp,
                          const Geometry& geom,
                          Real dt,
                          Vector<BCRec> const& h_bcrec,
-                         BCRec const* pbc)
+                         BCRec const* pbc,
+                         Array4<int const> const& bc_arr)
 {
     const Real dz = geom.CellSize(2);
     const Real dtdz = dt/dz;

--- a/Godunov/hydro_godunov_ppm.H
+++ b/Godunov/hydro_godunov_ppm.H
@@ -16,6 +16,8 @@ namespace PPM {
 
 enum limiters {VanLeer, WENOZ, NoLimiter};
 
+static constexpr int default_limiter = VanLeer;
+
 struct nolimiter {
 
     explicit nolimiter() = default;

--- a/Projections/hydro_MacProjector.H
+++ b/Projections/hydro_MacProjector.H
@@ -120,7 +120,10 @@ public:
     void setDomainBC (const amrex::Array<amrex::LinOpBCType,AMREX_SPACEDIM>& lobc,
                       const amrex::Array<amrex::LinOpBCType,AMREX_SPACEDIM>& hibc);
 
-    void setLevelBC  (int amrlev, const amrex::MultiFab* levelbcdata);
+    void setLevelBC  (int amrlev, const amrex::MultiFab* levelbcdata,
+                      const amrex::MultiFab* robin_a = nullptr,
+                      const amrex::MultiFab* robin_b = nullptr,
+                      const amrex::MultiFab* robin_f = nullptr);
 
     void setCoarseFineBC (const amrex::MultiFab* crse, int crse_ratio)
         { m_linop->setCoarseFineBC(crse, crse_ratio);}

--- a/Projections/hydro_MacProjector.cpp
+++ b/Projections/hydro_MacProjector.cpp
@@ -210,7 +210,7 @@ MacProjector::setLevelBC (int amrlev, const MultiFab* levelbcdata, const MultiFa
 {
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(!m_needs_domain_bcs,
                                      "setDomainBC must be called before setLevelBC");
-    m_linop->setLevelBC(amrlev, levelbcdata, robin_a, robin_b, robin_c);
+    m_linop->setLevelBC(amrlev, levelbcdata, robin_a, robin_b, robin_f);
     m_needs_level_bcs[amrlev] = false;
 }
 

--- a/Projections/hydro_MacProjector.cpp
+++ b/Projections/hydro_MacProjector.cpp
@@ -205,11 +205,12 @@ MacProjector::setDomainBC (const Array<LinOpBCType,AMREX_SPACEDIM>& lobc,
 
 
 void
-MacProjector::setLevelBC (int amrlev, const MultiFab* levelbcdata)
+MacProjector::setLevelBC (int amrlev, const MultiFab* levelbcdata, const MultiFab* robin_a,
+                          const MultiFab* robin_b, const MultiFab* robin_f)
 {
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(!m_needs_domain_bcs,
                                      "setDomainBC must be called before setLevelBC");
-    m_linop->setLevelBC(amrlev, levelbcdata);
+    m_linop->setLevelBC(amrlev, levelbcdata, robin_a, robin_b, robin_c);
     m_needs_level_bcs[amrlev] = false;
 }
 

--- a/Utils/hydro_bcs_K.H
+++ b/Utils/hydro_bcs_K.H
@@ -47,7 +47,8 @@ void SetXEdgeBCs( int i, int j, int k, int n,
                   amrex::Real &lo, amrex::Real &hi,
                   int bclo, int domlo,
                   int bchi, int domhi,
-                  bool is_velocity )
+                  bool is_velocity,
+                  const amrex::Array4<const int> const& bc_arr = {})
 {
 
     using namespace amrex;
@@ -57,7 +58,9 @@ void SetXEdgeBCs( int i, int j, int k, int n,
 
     if (i == domlo)
     {
-        if (bclo == BCType::ext_dir)
+        int bc = bc_arr ? bc_arr(domlo-1, j, k, n) : bclo;
+
+        if (bc==BCType::ext_dir)
         {
             lo = s(domlo-1, j, k, n);
             // For turbulent inflow, there are times when the inflow face
@@ -66,12 +69,12 @@ void SetXEdgeBCs( int i, int j, int k, int n,
             // tangential components to transport values from the interior.
             if ( n==XVEL && is_velocity ) hi=lo;
         }
-        else if ( bclo == BCType::foextrap || bclo == BCType::hoextrap ||
-                  bclo == BCType::reflect_even )
+        else if ( bc == BCType::foextrap || bc == BCType::hoextrap ||
+                  bc == BCType::reflect_even )
         {
             lo = hi;
         }
-        else if (bclo == BCType::reflect_odd)
+        else if (bc == BCType::reflect_odd)
         {
             hi = 0.;
             lo = hi;
@@ -79,17 +82,19 @@ void SetXEdgeBCs( int i, int j, int k, int n,
     }
     else if (i == domhi+1)
     {
-        if (bchi == BCType::ext_dir)
+        int bc = bc_arr ? bc_arr(domhi+1, j, k, n) : bchi;
+
+        if (bc==BCType::ext_dir)
         {
             hi = s(domhi+1, j, k, n);
             if ( n==XVEL && is_velocity ) lo = hi;
         }
-        else if ( bchi == BCType::foextrap || bchi == BCType::hoextrap ||
-                  bchi == BCType::reflect_even )
+        else if ( bc == BCType::foextrap || bc == BCType::hoextrap ||
+                  bc == BCType::reflect_even )
         {
             hi = lo;
         }
-        else if (bchi == BCType::reflect_odd)
+        else if (bc == BCType::reflect_odd)
         {
             lo = 0.;
             hi = lo;
@@ -114,7 +119,8 @@ void SetYEdgeBCs ( int i, int j, int k, int n,
                    amrex::Real &lo, amrex::Real &hi,
                    int bclo, int domlo,
                    int bchi, int domhi,
-                   bool is_velocity )
+                   bool is_velocity,
+                   const int mask = 0 )
 {
     using namespace amrex;
 
@@ -123,17 +129,19 @@ void SetYEdgeBCs ( int i, int j, int k, int n,
 
     if (j == domlo)
     {
-        if (bclo == BCType::ext_dir)
+        int bc = bc_arr ? bc_arr(i, domlo-1, k, n) : bclo;
+
+        if (bc==BCType::ext_dir)
         {
             lo = s(i, domlo-1, k, n);
             if ( n==YVEL && is_velocity ) hi=lo;
         }
-        else if ( bclo == BCType::foextrap || bclo == BCType::hoextrap ||
-                  bclo == BCType::reflect_even )
+        else if ( bc == BCType::foextrap || bc == BCType::hoextrap ||
+                  bc == BCType::reflect_even )
         {
             lo = hi;
         }
-        else if (bclo == BCType::reflect_odd)
+        else if (bc == BCType::reflect_odd)
         {
             hi = 0.;
             lo = hi;
@@ -141,17 +149,19 @@ void SetYEdgeBCs ( int i, int j, int k, int n,
     }
     else  if (j == domhi+1)
     {
-        if (bchi == BCType::ext_dir)
+        int bc = bc_arr ? bc_arr(i, domhi+1, k, n) : bchi;
+
+        if (bc==BCType::ext_dir)
         {
             hi = s(i, domhi+1, k, n);
             if ( n==YVEL && is_velocity ) lo=hi;
         }
-        else if ( bchi == BCType::foextrap || bchi == BCType::hoextrap ||
-                  bchi == BCType::reflect_even )
+        else if ( bc == BCType::foextrap || bc == BCType::hoextrap ||
+                  bc == BCType::reflect_even )
         {
             hi = lo;
         }
-        else if(bchi == BCType::reflect_odd)
+        else if(bc == BCType::reflect_odd)
         {
             lo = 0.;
             hi = lo;
@@ -181,7 +191,8 @@ void SetZEdgeBCs ( int i, int j, int k, int n,
                    amrex::Real &lo, amrex::Real &hi,
                    int bclo, int domlo,
                    int bchi, int domhi,
-                   bool is_velocity )
+                   bool is_velocity,
+                   const int mask = 0 )
 {
     using namespace amrex;
 
@@ -190,17 +201,19 @@ void SetZEdgeBCs ( int i, int j, int k, int n,
 
     if (k == domlo)
     {
-        if (bclo == BCType::ext_dir)
+        int bc = bc_arr ? bc_arr(i, j, domlo-1, n) : bclo;
+
+        if (bc==BCType::ext_dir)
         {
             lo = s(i, j, domlo-1, n);
             if ( n==ZVEL && is_velocity ) hi=lo;
         }
-        else if ( bclo == BCType::foextrap || bclo == BCType::hoextrap ||
-                  bclo == BCType::reflect_even )
+        else if ( bc == BCType::foextrap || bc == BCType::hoextrap ||
+                  bc == BCType::reflect_even )
         {
             lo = hi;
         }
-        else if(bclo == BCType::reflect_odd)
+        else if(bc == BCType::reflect_odd)
         {
             hi = 0.;
             lo = hi;
@@ -208,17 +221,19 @@ void SetZEdgeBCs ( int i, int j, int k, int n,
     }
     else if (k == domhi+1)
     {
-        if (bchi == BCType::ext_dir)
+        int bc = bc_arr ? bc_arr(i, j, domhi+1, n) : bchi;
+
+        if (bc==BCType::ext_dir)
         {
             hi = s(i,j,domhi+1, n);
             if ( n==ZVEL && is_velocity ) lo=hi;
         }
-        else if ( bchi == BCType::foextrap || bchi == BCType::hoextrap ||
-                  bchi == BCType::reflect_even )
+        else if ( bc == BCType::foextrap || bc == BCType::hoextrap ||
+                  bc == BCType::reflect_even )
         {
             hi = lo;
         }
-        else if(bchi == BCType::reflect_odd)
+        else if(bc == BCType::reflect_odd)
         {
             lo = 0.;
             hi = lo;

--- a/Utils/hydro_bcs_K.H
+++ b/Utils/hydro_bcs_K.H
@@ -30,36 +30,6 @@ namespace HydroBC{
     //
     // Choose between single BC per domain face or position dependent BC array
     //
-    // [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    //  const int lobc (const int dir, const int i, const int j, const int k, const int n,
-    //                 const Box& m_domain, const BCRec* bcr,
-    //                 Array4<int const> const& bca) ) const& noexcept
-    // {
-    //     if ( !bca ) { return bcr[n].lo(dir); }
-
-    //     IntVect index {AMREX_D_DECL(i,j,k)};
-    //     for ( int dim = 0; dim < AMREX_SPACEDIM; dim++){
-    //         if (index[dim] < m_domain.smallEnd(dim)) { index[dim] = m_domain.smallEnd(dim); }
-    //         if (index[dim] > m_domain.bigEnd(dim))   { index[dim] = m_domain.bigEnd(dim); }
-    //         if (dim == dir) { index[dim] = m_domain.smallEnd(dim)-1; }
-    //     }
-    //     return bca(index, n);
-    // };
-    // [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    // const int hibc (const int dir, const int i, const int j, const int k, const int n,
-    //                 const Box& m_domain, const BCRec* bcr,
-    //                 Array4<int const> const& bca) ) const& noexcept
-    // {
-    //     if ( !bca ) { return bcr[n].hi(dir); }
-
-    //     IntVect index {AMREX_D_DECL(i,j,k)};
-    //     for ( int dim = 0; dim < AMREX_SPACEDIM; dim++){
-    //         if (index[dim] < m_domain.smallEnd(dim)) { index[dim] = m_domain.smallEnd(dim); }
-    //         if (index[dim] > m_domain.bigEnd(dim))   { index[dim] = m_domain.bigEnd(dim); }
-    //         if (dim == dir) { index[dim] = m_domain.bigEnd(dim)+1; }
-    //     }
-    //     return bca(index, n);
-    // };
     [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     const amrex::BCRec getBC (const int i, const int j, const int k, const int n,
                               const amrex::Box& m_domain, const amrex::BCRec* bcr,

--- a/Utils/hydro_bcs_K.H
+++ b/Utils/hydro_bcs_K.H
@@ -48,7 +48,7 @@ void SetXEdgeBCs( int i, int j, int k, int n,
                   int bclo, int domlo,
                   int bchi, int domhi,
                   bool is_velocity,
-                  const amrex::Array4<const int> const& bc_arr = {})
+                  amrex::Array4<const int> const& bc_arr = {})
 {
 
     using namespace amrex;
@@ -120,7 +120,7 @@ void SetYEdgeBCs ( int i, int j, int k, int n,
                    int bclo, int domlo,
                    int bchi, int domhi,
                    bool is_velocity,
-                   const int mask = 0 )
+                   amrex::Array4<const int> const& bc_arr = {})
 {
     using namespace amrex;
 
@@ -192,7 +192,7 @@ void SetZEdgeBCs ( int i, int j, int k, int n,
                    int bclo, int domlo,
                    int bchi, int domhi,
                    bool is_velocity,
-                   const int mask = 0 )
+                   amrex::Array4<const int> const& bc_arr = {})
 {
     using namespace amrex;
 

--- a/Utils/hydro_bcs_K.H
+++ b/Utils/hydro_bcs_K.H
@@ -27,38 +27,38 @@
  *
  */
 namespace HydroBC{
-    //
-    // Choose between single BC per domain face or position dependent BC array
-    //
-    [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    const amrex::BCRec getBC (const int i, const int j, const int k, const int n,
-                              const amrex::Box& m_domain, const amrex::BCRec* bcr,
-                              amrex::Array4<int const> const& bca)
-    {
-        if ( !bca ) { return bcr[n]; }
+//
+// Choose between single BC per domain face or position dependent BC array
+//
+[[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+const amrex::BCRec getBC (const int i, const int j, const int k, const int n,
+                          const amrex::Box& m_domain, const amrex::BCRec* bcr,
+                          amrex::Array4<int const> const& bca)
+{
+    if ( !bca ) { return bcr[n]; }
 
-        int lo[AMREX_SPACEDIM];
-        int hi[AMREX_SPACEDIM];
-        for (int dir = 0; dir < AMREX_SPACEDIM; dir++) {
-            int index[] = {i,j,k};
+    int lo[AMREX_SPACEDIM];
+    int hi[AMREX_SPACEDIM];
+    for (int dir = 0; dir < AMREX_SPACEDIM; dir++) {
+        int index[] = {i,j,k};
 
-            for ( int dim = 0; dim < AMREX_SPACEDIM; dim++){
-                if (index[dim] < m_domain.smallEnd(dim)) { index[dim] = m_domain.smallEnd(dim); }
-                if (index[dim] > m_domain.bigEnd(dim))   { index[dim] = m_domain.bigEnd(dim); }
-                if (dim == dir) { index[dim] = m_domain.smallEnd(dim)-1; }
-            }
-            lo[dir] = bca.contains(index[0], index[1], index[2]) ?
-                bca(index[0], index[1], index[2], n) : 0;
+        for ( int dim = 0; dim < AMREX_SPACEDIM; dim++){
+            if (index[dim] < m_domain.smallEnd(dim)) { index[dim] = m_domain.smallEnd(dim); }
+            if (index[dim] > m_domain.bigEnd(dim))   { index[dim] = m_domain.bigEnd(dim); }
+            if (dim == dir) { index[dim] = m_domain.smallEnd(dim)-1; }
+        }
+        lo[dir] = bca.contains(index[0], index[1], index[2]) ?
+            bca(index[0], index[1], index[2], n) : 0;
 // FIXME?? if we don't contain (i,j,k) then it doesn't matter what the bc is there, because we don't touch it
 
-            index[dir] = m_domain.bigEnd(dir)+1;
-            hi[dir] = bca.contains(index[0], index[1], index[2]) ?
-                bca(index[0], index[1], index[2], n) : 0;
-        }
+        index[dir] = m_domain.bigEnd(dir)+1;
+        hi[dir] = bca.contains(index[0], index[1], index[2]) ?
+            bca(index[0], index[1], index[2], n) : 0;
+    }
 
-        amrex::BCRec bc(lo, hi);
-        return bc;
-    };
+    amrex::BCRec bc(lo, hi);
+    return bc;
+}
 
 /**
  *

--- a/Utils/hydro_bcs_K.H
+++ b/Utils/hydro_bcs_K.H
@@ -27,6 +27,68 @@
  *
  */
 namespace HydroBC{
+    //
+    // Choose between single BC per domain face or position dependent BC array
+    //
+    // [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    //  const int lobc (const int dir, const int i, const int j, const int k, const int n,
+    //                 const Box& m_domain, const BCRec* bcr,
+    //                 Array4<int const> const& bca) ) const& noexcept
+    // {
+    //     if ( !bca ) { return bcr[n].lo(dir); }
+
+    //     IntVect index {AMREX_D_DECL(i,j,k)};
+    //     for ( int dim = 0; dim < AMREX_SPACEDIM; dim++){
+    //         if (index[dim] < m_domain.smallEnd(dim)) { index[dim] = m_domain.smallEnd(dim); }
+    //         if (index[dim] > m_domain.bigEnd(dim))   { index[dim] = m_domain.bigEnd(dim); }
+    //         if (dim == dir) { index[dim] = m_domain.smallEnd(dim)-1; }
+    //     }
+    //     return bca(index, n);
+    // };
+    // [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    // const int hibc (const int dir, const int i, const int j, const int k, const int n,
+    //                 const Box& m_domain, const BCRec* bcr,
+    //                 Array4<int const> const& bca) ) const& noexcept
+    // {
+    //     if ( !bca ) { return bcr[n].hi(dir); }
+
+    //     IntVect index {AMREX_D_DECL(i,j,k)};
+    //     for ( int dim = 0; dim < AMREX_SPACEDIM; dim++){
+    //         if (index[dim] < m_domain.smallEnd(dim)) { index[dim] = m_domain.smallEnd(dim); }
+    //         if (index[dim] > m_domain.bigEnd(dim))   { index[dim] = m_domain.bigEnd(dim); }
+    //         if (dim == dir) { index[dim] = m_domain.bigEnd(dim)+1; }
+    //     }
+    //     return bca(index, n);
+    // };
+    [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    const amrex::BCRec getBC (const int i, const int j, const int k, const int n,
+                              const amrex::Box& m_domain, const amrex::BCRec* bcr,
+                              amrex::Array4<int const> const& bca)
+    {
+        if ( !bca ) { return bcr[n]; }
+
+        int lo[AMREX_SPACEDIM];
+        int hi[AMREX_SPACEDIM];
+        for (int dir = 0; dir < AMREX_SPACEDIM; dir++) {
+            int index[] = {i,j,k};
+
+            for ( int dim = 0; dim < AMREX_SPACEDIM; dim++){
+                if (index[dim] < m_domain.smallEnd(dim)) { index[dim] = m_domain.smallEnd(dim); }
+                if (index[dim] > m_domain.bigEnd(dim))   { index[dim] = m_domain.bigEnd(dim); }
+                if (dim == dir) { index[dim] = m_domain.smallEnd(dim)-1; }
+            }
+            lo[dir] = bca.contains(index[0], index[1], index[2]) ?
+                bca(index[0], index[1], index[2], n) : 0;
+// FIXME?? if we don't contain (i,j,k) then it doesn't matter what the bc is there, because we don't touch it
+
+            index[dir] = m_domain.bigEnd(dir)+1;
+            hi[dir] = bca.contains(index[0], index[1], index[2]) ?
+                bca(index[0], index[1], index[2], n) : 0;
+        }
+
+        amrex::BCRec bc(lo, hi);
+        return bc;
+    };
 
 /**
  *
@@ -47,8 +109,7 @@ void SetXEdgeBCs( int i, int j, int k, int n,
                   amrex::Real &lo, amrex::Real &hi,
                   int bclo, int domlo,
                   int bchi, int domhi,
-                  bool is_velocity,
-                  amrex::Array4<const int> const& bc_arr = {})
+                  bool is_velocity )
 {
 
     using namespace amrex;
@@ -58,9 +119,7 @@ void SetXEdgeBCs( int i, int j, int k, int n,
 
     if (i == domlo)
     {
-        int bc = bc_arr ? bc_arr(domlo-1, j, k, n) : bclo;
-
-        if (bc==BCType::ext_dir)
+        if (bclo == BCType::ext_dir)
         {
             lo = s(domlo-1, j, k, n);
             // For turbulent inflow, there are times when the inflow face
@@ -69,12 +128,12 @@ void SetXEdgeBCs( int i, int j, int k, int n,
             // tangential components to transport values from the interior.
             if ( n==XVEL && is_velocity ) hi=lo;
         }
-        else if ( bc == BCType::foextrap || bc == BCType::hoextrap ||
-                  bc == BCType::reflect_even )
+        else if ( bclo == BCType::foextrap || bclo == BCType::hoextrap ||
+                  bclo == BCType::reflect_even )
         {
             lo = hi;
         }
-        else if (bc == BCType::reflect_odd)
+        else if (bclo == BCType::reflect_odd)
         {
             hi = 0.;
             lo = hi;
@@ -82,19 +141,17 @@ void SetXEdgeBCs( int i, int j, int k, int n,
     }
     else if (i == domhi+1)
     {
-        int bc = bc_arr ? bc_arr(domhi+1, j, k, n) : bchi;
-
-        if (bc==BCType::ext_dir)
+        if (bchi == BCType::ext_dir)
         {
             hi = s(domhi+1, j, k, n);
             if ( n==XVEL && is_velocity ) lo = hi;
         }
-        else if ( bc == BCType::foextrap || bc == BCType::hoextrap ||
-                  bc == BCType::reflect_even )
+        else if ( bchi == BCType::foextrap || bchi == BCType::hoextrap ||
+                  bchi == BCType::reflect_even )
         {
             hi = lo;
         }
-        else if (bc == BCType::reflect_odd)
+        else if (bchi == BCType::reflect_odd)
         {
             lo = 0.;
             hi = lo;
@@ -119,8 +176,7 @@ void SetYEdgeBCs ( int i, int j, int k, int n,
                    amrex::Real &lo, amrex::Real &hi,
                    int bclo, int domlo,
                    int bchi, int domhi,
-                   bool is_velocity,
-                   amrex::Array4<const int> const& bc_arr = {})
+                   bool is_velocity )
 {
     using namespace amrex;
 
@@ -129,19 +185,17 @@ void SetYEdgeBCs ( int i, int j, int k, int n,
 
     if (j == domlo)
     {
-        int bc = bc_arr ? bc_arr(i, domlo-1, k, n) : bclo;
-
-        if (bc==BCType::ext_dir)
+        if (bclo == BCType::ext_dir)
         {
             lo = s(i, domlo-1, k, n);
             if ( n==YVEL && is_velocity ) hi=lo;
         }
-        else if ( bc == BCType::foextrap || bc == BCType::hoextrap ||
-                  bc == BCType::reflect_even )
+        else if ( bclo == BCType::foextrap || bclo == BCType::hoextrap ||
+                  bclo == BCType::reflect_even )
         {
             lo = hi;
         }
-        else if (bc == BCType::reflect_odd)
+        else if (bclo == BCType::reflect_odd)
         {
             hi = 0.;
             lo = hi;
@@ -149,19 +203,17 @@ void SetYEdgeBCs ( int i, int j, int k, int n,
     }
     else  if (j == domhi+1)
     {
-        int bc = bc_arr ? bc_arr(i, domhi+1, k, n) : bchi;
-
-        if (bc==BCType::ext_dir)
+        if (bchi == BCType::ext_dir)
         {
             hi = s(i, domhi+1, k, n);
             if ( n==YVEL && is_velocity ) lo=hi;
         }
-        else if ( bc == BCType::foextrap || bc == BCType::hoextrap ||
-                  bc == BCType::reflect_even )
+        else if ( bchi == BCType::foextrap || bchi == BCType::hoextrap ||
+                  bchi == BCType::reflect_even )
         {
             hi = lo;
         }
-        else if(bc == BCType::reflect_odd)
+        else if(bchi == BCType::reflect_odd)
         {
             lo = 0.;
             hi = lo;
@@ -191,8 +243,7 @@ void SetZEdgeBCs ( int i, int j, int k, int n,
                    amrex::Real &lo, amrex::Real &hi,
                    int bclo, int domlo,
                    int bchi, int domhi,
-                   bool is_velocity,
-                   amrex::Array4<const int> const& bc_arr = {})
+                   bool is_velocity )
 {
     using namespace amrex;
 
@@ -201,19 +252,17 @@ void SetZEdgeBCs ( int i, int j, int k, int n,
 
     if (k == domlo)
     {
-        int bc = bc_arr ? bc_arr(i, j, domlo-1, n) : bclo;
-
-        if (bc==BCType::ext_dir)
+        if (bclo == BCType::ext_dir)
         {
             lo = s(i, j, domlo-1, n);
             if ( n==ZVEL && is_velocity ) hi=lo;
         }
-        else if ( bc == BCType::foextrap || bc == BCType::hoextrap ||
-                  bc == BCType::reflect_even )
+        else if ( bclo == BCType::foextrap || bclo == BCType::hoextrap ||
+                  bclo == BCType::reflect_even )
         {
             lo = hi;
         }
-        else if(bc == BCType::reflect_odd)
+        else if(bclo == BCType::reflect_odd)
         {
             hi = 0.;
             lo = hi;
@@ -221,19 +270,17 @@ void SetZEdgeBCs ( int i, int j, int k, int n,
     }
     else if (k == domhi+1)
     {
-        int bc = bc_arr ? bc_arr(i, j, domhi+1, n) : bchi;
-
-        if (bc==BCType::ext_dir)
+        if (bchi == BCType::ext_dir)
         {
             hi = s(i,j,domhi+1, n);
             if ( n==ZVEL && is_velocity ) lo=hi;
         }
-        else if ( bc == BCType::foextrap || bc == BCType::hoextrap ||
-                  bc == BCType::reflect_even )
+        else if ( bchi == BCType::foextrap || bchi == BCType::hoextrap ||
+                  bchi == BCType::reflect_even )
         {
             hi = lo;
         }
-        else if(bc == BCType::reflect_odd)
+        else if(bchi == BCType::reflect_odd)
         {
             lo = 0.;
             hi = lo;

--- a/Utils/hydro_compute_edgestate_and_flux.cpp
+++ b/Utils/hydro_compute_edgestate_and_flux.cpp
@@ -123,7 +123,7 @@ namespace {
                                           geom,
                                           l_dt, d_bcrec, iconserv,
                                           godunov_use_ppm, godunov_use_forces_in_trans,
-                                          is_velocity, limiter_type); //fixme , bc_arr);
+                                          is_velocity, limiter_type, bc_arr);
             }
             else if (advection_type == "BDS")
             {

--- a/Utils/hydro_compute_edgestate_and_flux.cpp
+++ b/Utils/hydro_compute_edgestate_and_flux.cpp
@@ -44,7 +44,8 @@ namespace {
                       bool godunov_use_ppm, bool godunov_use_forces_in_trans,
                       bool is_velocity,
                       std::string const& advection_type,
-                      int limiter_type = PPM::VanLeer)
+                      int limiter_type,
+                      amrex::Array4<int const> const& bc_arr)
 
     {
 #ifdef AMREX_USE_EB
@@ -90,7 +91,7 @@ namespace {
                                             AMREX_D_DECL(apx,apy,apz), vfrac,
                                             AMREX_D_DECL(fcx,fcy,fcz), ccc,
                                             is_velocity,
-                                            values_on_eb_inflow);
+                                            values_on_eb_inflow, bc_arr);
             }
             else if (advection_type == "BDS")
             {
@@ -122,7 +123,7 @@ namespace {
                                           geom,
                                           l_dt, d_bcrec, iconserv,
                                           godunov_use_ppm, godunov_use_forces_in_trans,
-                                          is_velocity, limiter_type);
+                                          is_velocity, limiter_type); //fixme , bc_arr);
             }
             else if (advection_type == "BDS")
             {
@@ -165,7 +166,8 @@ HydroUtils::ComputeFluxesOnBoxFromState (Box const& bx, int ncomp, MFIter& mfi,
                                          bool godunov_use_ppm, bool godunov_use_forces_in_trans,
                                          bool is_velocity, bool fluxes_are_area_weighted,
                                          std::string const& advection_type,
-                                         int limiter_type)
+                                         int limiter_type,
+                                         amrex::Array4<int const> const& bc_arr)
 
 {
     ComputeFluxesOnBoxFromState(bx, ncomp, mfi, q,
@@ -177,7 +179,7 @@ HydroUtils::ComputeFluxesOnBoxFromState (Box const& bx, int ncomp, MFIter& mfi,
                                 ebfact, /*values_on_eb_inflow*/ Array4<Real const>{},
                                 godunov_use_ppm, godunov_use_forces_in_trans,
                                 is_velocity, fluxes_are_area_weighted, advection_type,
-                                limiter_type);
+                                limiter_type, bc_arr);
 
 }
 #endif
@@ -209,7 +211,8 @@ HydroUtils::ComputeFluxesOnBoxFromState (Box const& bx, int ncomp, MFIter& mfi,
                                          bool godunov_use_ppm, bool godunov_use_forces_in_trans,
                                          bool is_velocity, bool fluxes_are_area_weighted,
                                          std::string const& advection_type,
-                                         int limiter_type)
+                                         int limiter_type,
+                                         amrex::Array4<int const> const& bc_arr)
 
 {
     ComputeFluxesOnBoxFromState(bx, ncomp, mfi, q,
@@ -224,7 +227,7 @@ HydroUtils::ComputeFluxesOnBoxFromState (Box const& bx, int ncomp, MFIter& mfi,
 #endif
                                 godunov_use_ppm, godunov_use_forces_in_trans,
                                 is_velocity, fluxes_are_area_weighted, advection_type,
-                                limiter_type);
+                                limiter_type, bc_arr);
 
 }
 
@@ -257,7 +260,8 @@ HydroUtils::ComputeFluxesOnBoxFromState (Box const& bx, int ncomp, MFIter& mfi,
                                          bool godunov_use_ppm, bool godunov_use_forces_in_trans,
                                          bool is_velocity, bool fluxes_are_area_weighted,
                                          std::string const& advection_type,
-                                         int limiter_type)
+                                         int limiter_type,
+                                         amrex::Array4<int const> const& bc_arr)
 
 {
 #ifdef AMREX_USE_EB
@@ -284,7 +288,7 @@ HydroUtils::ComputeFluxesOnBoxFromState (Box const& bx, int ncomp, MFIter& mfi,
                          ebfact, values_on_eb_inflow, regular,
 #endif
                          godunov_use_ppm, godunov_use_forces_in_trans,
-                         is_velocity, advection_type, limiter_type);
+                         is_velocity, advection_type, limiter_type, bc_arr);
     }
 
     // Compute fluxes.

--- a/Utils/hydro_extrap_vel_to_faces.cpp
+++ b/Utils/hydro_extrap_vel_to_faces.cpp
@@ -56,6 +56,8 @@ HydroUtils::ExtrapVelToFaces ( amrex::MultiFab const& vel,
                                int limiter_type,
                                iMultiFab* BC_MF)
 {
+    amrex::ignore_unused(BC_MF);
+
     if (advection_type == "Godunov") {
 #ifdef AMREX_USE_EB
         if (!ebfact.isAllRegular())
@@ -63,7 +65,7 @@ HydroUtils::ExtrapVelToFaces ( amrex::MultiFab const& vel,
                                         AMREX_D_DECL(u_mac, v_mac, w_mac),
                                         h_bcrec, d_bcrec, geom, dt,
                                         velocity_on_eb_inflow,
-                                        // Note that PPM not supported for EB
+                                        // Note that PPM is not supported for EB
                                         BC_MF);
         else
 #endif

--- a/Utils/hydro_extrap_vel_to_faces.cpp
+++ b/Utils/hydro_extrap_vel_to_faces.cpp
@@ -53,7 +53,8 @@ HydroUtils::ExtrapVelToFaces ( amrex::MultiFab const& vel,
 #endif
                                bool godunov_ppm, bool godunov_use_forces_in_trans,
                                std::string const& advection_type,
-                               int limiter_type)
+                               int limiter_type,
+                               iMultiFab* BC_MF)
 {
     if (advection_type == "Godunov") {
 #ifdef AMREX_USE_EB
@@ -61,7 +62,9 @@ HydroUtils::ExtrapVelToFaces ( amrex::MultiFab const& vel,
             EBGodunov::ExtrapVelToFaces(vel, vel_forces,
                                         AMREX_D_DECL(u_mac, v_mac, w_mac),
                                         h_bcrec, d_bcrec, geom, dt,
-                                        velocity_on_eb_inflow);  // Note that PPM not supported for EB
+                                        velocity_on_eb_inflow,
+                                        // Note that PPM not supported for EB
+                                        BC_MF);
         else
 #endif
             Godunov::ExtrapVelToFaces(vel, vel_forces,

--- a/Utils/hydro_utils.H
+++ b/Utils/hydro_utils.H
@@ -154,7 +154,8 @@ ExtrapVelToFaces ( amrex::MultiFab const& vel,
 #endif
                    bool godunov_ppm, bool godunov_use_forces_in_trans,
                    std::string const& advection_type,
-                   int limiter_type = PPM::VanLeer);
+                   int limiter_type = PPM::VanLeer,
+                   amrex::iMultiFab* BC_MF = nullptr);
 
 /**
  * \brief If convective, compute convTerm = u dot grad q = div (u q) - q div(u).

--- a/Utils/hydro_utils.H
+++ b/Utils/hydro_utils.H
@@ -20,7 +20,6 @@
  */
 
 namespace HydroUtils {
-
 /**
  * \brief Compute edge state and flux. Most general version for use with multilevel synchonization.
  *
@@ -55,7 +54,7 @@ ComputeFluxesOnBoxFromState ( amrex::Box const& bx, int ncomp, amrex::MFIter& mf
                               bool godunov_use_ppm, bool godunov_use_forces_in_trans,
                               bool is_velocity, bool fluxes_are_area_weighted,
                               std::string const& advection_type,
-                              int limiter_type = PPM::VanLeer);
+                              int limiter_type = PPM::default_limiter);
 /**
  * \brief Compute edge state and flux. For typical advection, and also allows for inflow on EB.
  *
@@ -87,7 +86,7 @@ ComputeFluxesOnBoxFromState ( amrex::Box const& bx, int ncomp, amrex::MFIter& mf
                               bool godunov_use_ppm, bool godunov_use_forces_in_trans,
                               bool is_velocity, bool fluxes_are_area_weighted,
                               std::string const& advection_type,
-                              int limiter_type = PPM::VanLeer);
+                              int limiter_type = PPM::default_limiter);
 
 /**
  * \brief Compute edge state and flux. For typical advection, but no inflow through EB.
@@ -118,7 +117,7 @@ ComputeFluxesOnBoxFromState ( amrex::Box const& bx, int ncomp, amrex::MFIter& mf
                              bool godunov_use_ppm, bool godunov_use_forces_in_trans,
                              bool is_velocity, bool fluxes_are_area_weighted,
                              std::string const& advection_type,
-                             int limiter_type = PPM::VanLeer);
+                             int limiter_type = PPM::default_limiter);
 #endif
 
 #ifdef AMREX_USE_EB
@@ -135,7 +134,7 @@ ExtrapVelToFaces ( amrex::MultiFab const& vel,
                    const amrex::EBFArrayBoxFactory& ebfact,
                    bool godunov_ppm, bool godunov_use_forces_in_trans,
                    std::string const& advection_type,
-                   int limiter_type = PPM::VanLeer);
+                   int limiter_type = PPM::default_limiter);
 #endif
 
 void
@@ -154,7 +153,7 @@ ExtrapVelToFaces ( amrex::MultiFab const& vel,
 #endif
                    bool godunov_ppm, bool godunov_use_forces_in_trans,
                    std::string const& advection_type,
-                   int limiter_type = PPM::VanLeer,
+                   int limiter_type = PPM::default_limiter,
                    amrex::iMultiFab* BC_MF = nullptr);
 
 /**

--- a/Utils/hydro_utils.H
+++ b/Utils/hydro_utils.H
@@ -22,7 +22,7 @@
 namespace HydroUtils {
 /**
  * \brief Compute edge state and flux. Most general version for use with multilevel synchonization.
- *
+ *        All other versions ultimately call this one.
  */
 void
 ComputeFluxesOnBoxFromState ( amrex::Box const& bx, int ncomp, amrex::MFIter& mfi,
@@ -54,7 +54,8 @@ ComputeFluxesOnBoxFromState ( amrex::Box const& bx, int ncomp, amrex::MFIter& mf
                               bool godunov_use_ppm, bool godunov_use_forces_in_trans,
                               bool is_velocity, bool fluxes_are_area_weighted,
                               std::string const& advection_type,
-                              int limiter_type = PPM::default_limiter);
+                              int limiter_type = PPM::default_limiter,
+                              amrex::Array4<int const> const& bc_arr = {});
 /**
  * \brief Compute edge state and flux. For typical advection, and also allows for inflow on EB.
  *
@@ -86,7 +87,8 @@ ComputeFluxesOnBoxFromState ( amrex::Box const& bx, int ncomp, amrex::MFIter& mf
                               bool godunov_use_ppm, bool godunov_use_forces_in_trans,
                               bool is_velocity, bool fluxes_are_area_weighted,
                               std::string const& advection_type,
-                              int limiter_type = PPM::default_limiter);
+                              int limiter_type = PPM::default_limiter,
+                              amrex::Array4<int const> const& bc_arr = {});
 
 /**
  * \brief Compute edge state and flux. For typical advection, but no inflow through EB.
@@ -117,7 +119,8 @@ ComputeFluxesOnBoxFromState ( amrex::Box const& bx, int ncomp, amrex::MFIter& mf
                              bool godunov_use_ppm, bool godunov_use_forces_in_trans,
                              bool is_velocity, bool fluxes_are_area_weighted,
                              std::string const& advection_type,
-                             int limiter_type = PPM::default_limiter);
+                              int limiter_type = PPM::default_limiter,
+                              amrex::Array4<int const> const& bc_arr = {});
 #endif
 
 #ifdef AMREX_USE_EB


### PR DESCRIPTION
For the MacProjector, allow specifying Robin BCs (since mixed BCs can be viewed as a special case of this).

For (EB)Godunov, this has been implemented by allowing the option to pass a position dependent BC MF/Array4. The BC MF is cell-centered and carries the amrex::BCType type in the first ghost cell (precedent set by MLMG's treatment of Robin BCs) and must fully specify the BC on all faces. If a position dependent BCs are passed in, they take precedent and single bc per face BCRecs are ignored.