### PR TITLE
MAC projector with Robin BCs needs initialization every time. The

### DIFF
--- a/Projections/hydro_MacProjector.cpp
+++ b/Projections/hydro_MacProjector.cpp
@@ -212,9 +212,10 @@ MacProjector::setLevelBC (int amrlev, const MultiFab* levelbcdata, const MultiFa
                                      "setDomainBC must be called before setLevelBC");
     m_linop->setLevelBC(amrlev, levelbcdata, robin_a, robin_b, robin_f);
     m_needs_level_bcs[amrlev] = false;
-    m_needs_init = true; // Solver is not safe for reuse with Robin BC
+    if (robin_a) {
+        m_needs_init = true; // Solver is not safe for reuse with Robin BC
+    }
 }
-
 
 
 void

--- a/Projections/hydro_MacProjector.cpp
+++ b/Projections/hydro_MacProjector.cpp
@@ -212,6 +212,7 @@ MacProjector::setLevelBC (int amrlev, const MultiFab* levelbcdata, const MultiFa
                                      "setDomainBC must be called before setLevelBC");
     m_linop->setLevelBC(amrlev, levelbcdata, robin_a, robin_b, robin_f);
     m_needs_level_bcs[amrlev] = false;
+    m_needs_init = true; // Solver is not safe for reuse with Robin BC
 }
 
 


### PR DESCRIPTION
underlying solver, (EB)MLABecLaplacian, is not safe for reuse with Robin BCs.