### PR TITLE
Allow outflow to be zero when inflow is zero while enforcing solvability

### DIFF
--- a/EBGodunov/hydro_ebgodunov_bcs_K.H
+++ b/EBGodunov/hydro_ebgodunov_bcs_K.H
@@ -66,7 +66,7 @@ void SetXBCs (const int i, const int j, const int k, const int n,
             //
             // Note that this is only relevant for 3D, as only 3D ever needs to
             // set the BC beyond the domain face.
-            // This is potentially tricky because the code re-uses some of the
+            // This is potentially tricky because the code reuses some of the
             // space holding the holding the states passed in here; it puts the
             // upwinded intermediate edge state in Imx (which supplies hi)
             // With GPU, I think it's undertermined which Imx(i+..) you'll get here,


### PR DESCRIPTION
This fixes a bug in the existing code which requires the outflow to be non-zero even if the inflow is zero for the direction-dependent boundaries. It should be okay for the outflow to be zero when inflow is zero, e.g. for finer levels that are not touching the boundary at all, or even in general. 