### PR TITLE
MacProjector: avoid setting phi_inout to 0

### DIFF
--- a/Projections/hydro_MacProjector.H
+++ b/Projections/hydro_MacProjector.H
@@ -143,6 +143,7 @@ public:
     //
     void project (const amrex::Vector<amrex::MultiFab*>& phi_in, amrex::Real reltol, amrex::Real atol);
     void project (amrex::Real reltol, amrex::Real atol);
+    void project_doit (amrex::Real reltol, amrex::Real atol);
 
     //
     // Get Fluxes.  DO NOT USE LinOp to get fluxes!!!


### PR DESCRIPTION
Important for overset: if phi is set to 0, those values are being masked/enforced, not the ones input to the routine.

When phi is not passed in to project(), this retains the same behavior, setting phi = 0 before solving.