### PR TITLE
Getters for debugging

### DIFF
--- a/Projections/hydro_MacProjector.H
+++ b/Projections/hydro_MacProjector.H
@@ -165,6 +165,9 @@ public:
 
     [[nodiscard]] bool needInitialization()  const noexcept { return m_needs_init; }
 
+    // Methods to get phi and rhs for debugging
+    [[nodiscard]] const amrex::Vector<amrex::MultiFab>& getPhi() const noexcept { return m_phi; }
+    [[nodiscard]] const amrex::Vector<amrex::MultiFab>& getRhs() const noexcept { return m_rhs; }
 private:
     void setOptions ();
 

--- a/Projections/hydro_MacProjector.H
+++ b/Projections/hydro_MacProjector.H
@@ -167,7 +167,7 @@ public:
 
     // Methods to get phi and rhs for debugging
     [[nodiscard]] const amrex::Vector<amrex::MultiFab>& getPhi() const noexcept { return m_phi; }
-    [[nodiscard]] const amrex::Vector<amrex::MultiFab>& getRhs() const noexcept { return m_rhs; }
+    [[nodiscard]] const amrex::Vector<amrex::MultiFab>& getRHS() const noexcept { return m_rhs; }
 private:
     void setOptions ();
 

--- a/Projections/hydro_NodalProjector.H
+++ b/Projections/hydro_NodalProjector.H
@@ -82,7 +82,7 @@ public:
     amrex::Vector< const amrex::MultiFab* > getPhiConst     () const {return GetVecOfConstPtrs(m_phi);}
     amrex::Vector<       amrex::MultiFab* > getRHS          ()       {return GetVecOfPtrs(m_rhs);}
     amrex::Vector< const amrex::MultiFab* > getRHSConst     () const {return GetVecOfConstPtrs(m_rhs);}
-    
+
     amrex::Vector<       amrex::MultiFab* > calcGradPhi     (const amrex::Vector<amrex::MultiFab*>& a_phi);
 
     void computeRHS ( const amrex::Vector<amrex::MultiFab*>&       a_rhs,

--- a/Projections/hydro_NodalProjector.H
+++ b/Projections/hydro_NodalProjector.H
@@ -80,7 +80,9 @@ public:
     amrex::Vector< const amrex::MultiFab* > getGradPhiConst () const {return GetVecOfConstPtrs(m_fluxes);}
     amrex::Vector<       amrex::MultiFab* > getPhi          ()       {return GetVecOfPtrs(m_phi);}
     amrex::Vector< const amrex::MultiFab* > getPhiConst     () const {return GetVecOfConstPtrs(m_phi);}
-
+    amrex::Vector<       amrex::MultiFab* > getRHS          ()       {return GetVecOfPtrs(m_rhs);}
+    amrex::Vector< const amrex::MultiFab* > getRHSConst     () const {return GetVecOfConstPtrs(m_rhs);}
+    
     amrex::Vector<       amrex::MultiFab* > calcGradPhi     (const amrex::Vector<amrex::MultiFab*>& a_phi);
 
     void computeRHS ( const amrex::Vector<amrex::MultiFab*>&       a_rhs,


### PR DESCRIPTION
This pull request adds new getter methods to the `MacProjector` and `NodalProjector` classes to aid in debugging in PeleLMeX.