### PR TITLE
Convert _OPENMP to AMREX_USE_OMP

### DIFF
--- a/EBGodunov/hydro_ebgodunov_extrap_vel_to_faces.cpp
+++ b/EBGodunov/hydro_ebgodunov_extrap_vel_to_faces.cpp
@@ -47,7 +47,7 @@ EBGodunov::ExtrapVelToFaces ( MultiFab const& vel,
                   w_mac.setVal(hydro_covered_val););
 
     const int ncomp = AMREX_SPACEDIM;
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     {

--- a/EBMOL/hydro_ebmol_extrap_vel_to_faces.cpp
+++ b/EBMOL/hydro_ebmol_extrap_vel_to_faces.cpp
@@ -36,7 +36,7 @@ EBMOL::ExtrapVelToFaces ( const MultiFab&  a_vel,
     auto const& ccent = fact.getCentroid();
 #endif
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     {

--- a/Godunov/hydro_godunov_extrap_vel_to_faces_2D.cpp
+++ b/Godunov/hydro_godunov_extrap_vel_to_faces_2D.cpp
@@ -28,7 +28,7 @@ Godunov::ExtrapVelToFaces ( MultiFab const& a_vel,
     Box const& domain = geom.Domain();
     const Real* dx    = geom.CellSize();
     const int ncomp = AMREX_SPACEDIM;
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     {

--- a/Godunov/hydro_godunov_extrap_vel_to_faces_3D.cpp
+++ b/Godunov/hydro_godunov_extrap_vel_to_faces_3D.cpp
@@ -31,7 +31,7 @@ Godunov::ExtrapVelToFaces ( MultiFab const& a_vel,
     const Real* dx    = geom.CellSize();
 
     const int ncomp = AMREX_SPACEDIM;
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     {

--- a/MOL/hydro_mol_extrap_vel_to_faces.cpp
+++ b/MOL/hydro_mol_extrap_vel_to_faces.cpp
@@ -26,7 +26,7 @@ MOL::ExtrapVelToFaces ( const MultiFab&  a_vel,
 {
     BL_PROFILE("MOL::ExtrapVelToFaces");
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     {


### PR DESCRIPTION
There is currently a mix of `_OPENMP` and `AMREX_USE_OMP` in this repo. Should we convert all to `AMREX_USE_OMP`?